### PR TITLE
fix: incorrect RDF/XML attribute usage in pdf metadata

### DIFF
--- a/packages/node-zugferd/src/pdf-formatter.ts
+++ b/packages/node-zugferd/src/pdf-formatter.ts
@@ -88,7 +88,7 @@ export const addPdfMetadata = (
 						"pdfaExtension:schemas": {
 							"rdf:Bag": {
 								"rdf:li": {
-									"@rdf:parseSchema": "Resource",
+									"@rdf:parseType": "Resource",
 									"pdfaSchema:schema": "Factur-X PDFA Extension Schema",
 									"pdfaSchema:namespaceURI":
 										"urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#",


### PR DESCRIPTION
Fixes incorrect usage of non existent attribute  `rdf:parseSchema` to use the correct attribute `rdf:parseType` instead.

closes https://github.com/jslno/node-zugferd/issues/8