### PR TITLE
feat: add strict mode constraint

### DIFF
--- a/packages/node-zugferd/package.json
+++ b/packages/node-zugferd/package.json
@@ -46,8 +46,10 @@
 		"defu": "^6.1.4",
 		"fast-xml-parser": "^4.5.1",
 		"pdf-lib": "^1.17.1",
-		"xsd-schema-validator": "^0.10.0",
 		"zod": "^3.24.1"
+	},
+	"optionalDependencies": {
+		"xsd-schema-validator": "^0.10.0"
 	},
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/packages/node-zugferd/src/profiles/factory.ts
+++ b/packages/node-zugferd/src/profiles/factory.ts
@@ -21,6 +21,9 @@ export const createProfile = <P extends Profile>(options: P) => {
 		},
 		validate: async (data: string | Buffer | { file: string }) => {
 			try {
+				if (!validateXML) {
+					throw new Error("Missing dependency xsd-schema-validator");
+				}
 				const res = await validateXML(data, options.xsdPath);
 
 				return res.valid;

--- a/packages/node-zugferd/src/types/options.ts
+++ b/packages/node-zugferd/src/types/options.ts
@@ -2,4 +2,5 @@ import { type ProfileContext } from "./profile";
 
 export type ZugferdOptions = {
 	profile: ProfileContext;
+	strict?: boolean;
 };

--- a/packages/node-zugferd/src/zugferd.ts
+++ b/packages/node-zugferd/src/zugferd.ts
@@ -3,10 +3,18 @@ import { init } from "./init";
 import { type ZugferdOptions } from "./types/options";
 import { AFRelationship, type AttachmentOptions, PDFDocument } from "pdf-lib";
 import { type PDFAMetadata } from "./formatter/pdf";
+import type { ProfileValidateHandler } from "./types";
 
 export const zugferd = <O extends ZugferdOptions>(options: O) => {
 	const context = init(options);
-	const { validate } = options.profile;
+	
+	const validate: ProfileValidateHandler = async (data) => {
+		if (options.strict === false) {
+			return true;
+		}
+
+		return options.profile.validate(data);
+	};
 
 	return {
 		context,

--- a/packages/node-zugferd/src/zugferd.ts
+++ b/packages/node-zugferd/src/zugferd.ts
@@ -7,7 +7,6 @@ import type { ProfileValidateHandler } from "./types";
 
 export const zugferd = <O extends ZugferdOptions>(options: O) => {
 	const context = init(options);
-	
 	const validate: ProfileValidateHandler = async (data) => {
 		if (options.strict === false) {
 			return true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,12 +169,13 @@ importers:
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
-      xsd-schema-validator:
-        specifier: ^0.10.0
-        version: 0.10.0
       zod:
         specifier: ^3.24.1
         version: 3.24.2
+    optionalDependencies:
+      xsd-schema-validator:
+        specifier: ^0.10.0
+        version: 0.10.0
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4


### PR DESCRIPTION
makes `xsd-schema-validator` optional when setting `strict: false` inside `zugferd()`. When strict is false xsd-schema-validator wont be used internally. It'll also safely ignore any errors while installing xsd-schema-validator.

closes #26 