### PR TITLE
add missing business term keys for BG-1 (BT-21, BT-22)

### DIFF
--- a/packages/node-zugferd/src/profiles/basic-wl/schema.ts
+++ b/packages/node-zugferd/src/profiles/basic-wl/schema.ts
@@ -33,6 +33,7 @@ A group of business terms providing textual notes that are relevant for the invo
 			 * Such as the reason for any correction or assignment note in case the invoice has been factored.
 			 */
 			content: {
+				key: "BT-22",
 				type: "string",
 				description: `**Invoice note**
 
@@ -58,6 +59,7 @@ Such as the reason for any correction or assignment note in case the invoice has
 			 * - CUS: Customs Information
 			 */
 			subjectCode: {
+				key: "BT-21",
 				type: UNTDID_4451.map(({ code }) => code),
 				description: `**Invoice note subject code**
 

--- a/packages/node-zugferd/src/profiles/extended/schema.ts
+++ b/packages/node-zugferd/src/profiles/extended/schema.ts
@@ -99,6 +99,7 @@ Valid languages are registered with the ISO 639-2 "Codes for the representation 
 			 * The code is bilaterally agreed on and must have the same meaning as BT-22.
 			 */
 			contentCode: {
+				key: "BT-21",
 				type: "string",
 				description: `**Free text on header level (qualifying the content)**
 


### PR DESCRIPTION
I added the business terms for note code and note content, since I use the schema from this repository I would be glad to get that merged :) 