### PR TITLE
add BT-24 specification identifier

### DIFF
--- a/packages/node-zugferd/src/formatter/xml/formatter.ts
+++ b/packages/node-zugferd/src/formatter/xml/formatter.ts
@@ -62,7 +62,6 @@ export const mergeSchemas = (profile: Profile): Schema => {
 };
 
 export type ParseSchemaOptions = {
-	contextParameter: string;
 	groupIndices?: GroupIndices;
 };
 
@@ -89,13 +88,6 @@ export const parseSchema = <S extends Schema>(
 			"@xmlns:xs": "http://www.w3.org/2001/XMLSchema",
 			"@xmlns:udt":
 				"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100",
-			"rsm:ExchangedDocumentContext": {
-				"ram:GuidelineSpecifiedDocumentContextParameter": {
-					"ram:ID": {
-						"#": options.contextParameter,
-					},
-				},
-			},
 		},
 	};
 	const localGroupIndices: GroupIndices = { ...parentGroupIndices };

--- a/packages/node-zugferd/src/profiles/basic-wl/mask.ts
+++ b/packages/node-zugferd/src/profiles/basic-wl/mask.ts
@@ -1,5 +1,6 @@
 export const basicWlMask = {
 	businessProcessType: "BT-23",
+	specificationIdentifier: "BT-24",
 	number: "BT-1",
 	typeCode: "BT-3",
 	issueDate: "BT-2",

--- a/packages/node-zugferd/src/profiles/basic-wl/schema.ts
+++ b/packages/node-zugferd/src/profiles/basic-wl/schema.ts
@@ -11,6 +11,11 @@ import { ISO_6523 } from "../../codelists/iso/6523.gen";
 import { ISO_3166 } from "../../codelists/iso/3166";
 
 export const basicWlSchema = {
+	specificationIdentifier: {
+		type: "string",
+		required: false,
+		defaultValue: "urn:factur-x.eu:1p0:basicwl",
+	},
 	/**
 	 * Invoice Note
 	 *

--- a/packages/node-zugferd/src/profiles/basic/mask.ts
+++ b/packages/node-zugferd/src/profiles/basic/mask.ts
@@ -1,5 +1,6 @@
 export const basicMask = {
 	businessProcessType: "BT-23",
+	specificationIdentifier: "BT-24",
 	number: "BT-1",
 	typeCode: "BT-3",
 	issueDate: "BT-2",

--- a/packages/node-zugferd/src/profiles/basic/schema.ts
+++ b/packages/node-zugferd/src/profiles/basic/schema.ts
@@ -9,6 +9,11 @@ import { REC21 } from "../../codelists/rec21.gen";
 import { ISO_6523 } from "../../codelists/iso/6523.gen";
 
 export const basicSchema = {
+	specificationIdentifier: {
+		type: "string",
+		required: false,
+		defaultValue: "urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic",
+	},
 	transaction: {
 		type: "object",
 		required: false,

--- a/packages/node-zugferd/src/profiles/en16931/mask.ts
+++ b/packages/node-zugferd/src/profiles/en16931/mask.ts
@@ -1,5 +1,6 @@
 export const en16931Mask = {
 	businessProcessType: "BT-23",
+	specificationIdentifier: "BT-24",
 	number: "BT-1",
 	typeCode: "BT-3",
 	issueDate: "BT-2",

--- a/packages/node-zugferd/src/profiles/en16931/schema.ts
+++ b/packages/node-zugferd/src/profiles/en16931/schema.ts
@@ -9,8 +9,7 @@ export const en16931Schema = {
 	specificationIdentifier: {
 		type: "string",
 		required: false,
-		defaultValue:
-			"urn:cen.eu:en16931:2017",
+		defaultValue: "urn:cen.eu:en16931:2017",
 	},
 	transaction: {
 		type: "object",

--- a/packages/node-zugferd/src/profiles/en16931/schema.ts
+++ b/packages/node-zugferd/src/profiles/en16931/schema.ts
@@ -6,6 +6,12 @@ import { UNTDID_7143 } from "../../codelists/untdid/7143.gen";
 import { ISO_3166 } from "../../codelists/iso/3166";
 
 export const en16931Schema = {
+	specificationIdentifier: {
+		type: "string",
+		required: false,
+		defaultValue:
+			"urn:cen.eu:en16931:2017",
+	},
 	transaction: {
 		type: "object",
 		shape: {

--- a/packages/node-zugferd/src/profiles/extended/mask.ts
+++ b/packages/node-zugferd/src/profiles/extended/mask.ts
@@ -1,6 +1,7 @@
 export const extendedMask = {
 	testIndicator: "BT-X-1-00",
 	businessProcessType: "BT-23",
+	specificationIdentifier: "BT-24",
 	number: "BT-1",
 	name: "BT-X-2",
 	typeCode: "BT-3",

--- a/packages/node-zugferd/src/profiles/extended/schema.ts
+++ b/packages/node-zugferd/src/profiles/extended/schema.ts
@@ -17,6 +17,12 @@ import { ISO_3166 } from "../../codelists/iso/3166";
 import { ISO_639_2 } from "../../codelists/iso/639-2";
 
 export const extendedSchema = {
+	specificationIdentifier: {
+		type: "string",
+		required: false,
+		defaultValue:
+			"urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended",
+	},
 	/**
 	 * Test Indicator
 	 *

--- a/packages/node-zugferd/src/profiles/factory.ts
+++ b/packages/node-zugferd/src/profiles/factory.ts
@@ -9,9 +9,7 @@ export const createProfile = <P extends Profile>(options: P) => {
 			const xmlObj = ctx.context.parseSchema(
 				ctx.data as InferSchema<P>,
 				ctx.context.mergeSchemas(options),
-				{
-					contextParameter: options.contextParameter,
-				},
+				{},
 				{},
 				ctx.data,
 			);

--- a/packages/node-zugferd/src/profiles/minimum/mask.ts
+++ b/packages/node-zugferd/src/profiles/minimum/mask.ts
@@ -1,5 +1,6 @@
 export const minimumMask = {
 	businessProcessType: "BT-23",
+	specificationIdentifier: "BT-24",
 	number: "BT-1",
 	typeCode: "BT-3",
 	issueDate: "BT-2",

--- a/packages/node-zugferd/src/profiles/minimum/schema.ts
+++ b/packages/node-zugferd/src/profiles/minimum/schema.ts
@@ -33,20 +33,20 @@ CHORUSPRO: this data makes it possible to inform the "cadre de facturation" (bil
 		xpath:
 			"/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:BusinessProcessSpecifiedDocumentContextParameter/ram:ID",
 	},
-  /**
-   * Specification Identifier
-   *
-   * A specification identifier containing the entire set of rules regarding semantic content, cardinalities, and business rules to which the data contained in the invoice conforms.
-   *
-   * Note: This declares conformity to the respective document. 
-   *
-   * For the reference to the EU standard, "urn:cen.eu:en16931:2017" must be specified. 
-   *
-   * Invoices that are compliant with CIUS XRechnung should specify "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0" here. 
-   *
-   * Invoices that comply with the XRechnung extension should specify "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0#conformant#urn:xeinkauf.de:kosit:extension:xrechnung_3.0" here. No schema is required.
-   */
-  specificationIdentifier: {
+	/**
+	 * Specification Identifier
+	 *
+	 * A specification identifier containing the entire set of rules regarding semantic content, cardinalities, and business rules to which the data contained in the invoice conforms.
+	 *
+	 * Note: This declares conformity to the respective document.
+	 *
+	 * For the reference to the EU standard, "urn:cen.eu:en16931:2017" must be specified.
+	 *
+	 * Invoices that are compliant with CIUS XRechnung should specify "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0" here.
+	 *
+	 * Invoices that comply with the XRechnung extension should specify "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0#conformant#urn:xeinkauf.de:kosit:extension:xrechnung_3.0" here. No schema is required.
+	 */
+	specificationIdentifier: {
 		key: "BT-24",
 		type: "string",
 		required: false,

--- a/packages/node-zugferd/src/profiles/minimum/schema.ts
+++ b/packages/node-zugferd/src/profiles/minimum/schema.ts
@@ -50,6 +50,7 @@ CHORUSPRO: this data makes it possible to inform the "cadre de facturation" (bil
 		key: "BT-24",
 		type: "string",
 		required: false,
+		defaultValue: "urn:factur-x.eu:1p0:minimum",
 		description: `**Specification Identifier**
 A specification identifier containing the entire set of rules regarding semantic content, cardinalities, and business rules to which the data contained in the invoice conforms.
 

--- a/packages/node-zugferd/src/profiles/minimum/schema.ts
+++ b/packages/node-zugferd/src/profiles/minimum/schema.ts
@@ -33,6 +33,36 @@ CHORUSPRO: this data makes it possible to inform the "cadre de facturation" (bil
 		xpath:
 			"/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:BusinessProcessSpecifiedDocumentContextParameter/ram:ID",
 	},
+  /**
+   * Specification Identifier
+   *
+   * A specification identifier containing the entire set of rules regarding semantic content, cardinalities, and business rules to which the data contained in the invoice conforms.
+   *
+   * Note: This declares conformity to the respective document. 
+   *
+   * For the reference to the EU standard, "urn:cen.eu:en16931:2017" must be specified. 
+   *
+   * Invoices that are compliant with CIUS XRechnung should specify "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0" here. 
+   *
+   * Invoices that comply with the XRechnung extension should specify "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0#conformant#urn:xeinkauf.de:kosit:extension:xrechnung_3.0" here. No schema is required.
+   */
+  specificationIdentifier: {
+		key: "BT-24",
+		type: "string",
+		required: false,
+		description: `**Specification Identifier**
+A specification identifier containing the entire set of rules regarding semantic content, cardinalities, and business rules to which the data contained in the invoice conforms.
+
+Note: This declares conformity to the respective document. 
+
+For the reference to the EU standard, "urn:cen.eu:en16931:2017" must be specified. 
+
+Invoices that are compliant with CIUS XRechnung should specify "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0" here. 
+
+Invoices that comply with the XRechnung extension should specify "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0#conformant#urn:xeinkauf.de:kosit:extension:xrechnung_3.0" here. No schema is required.`,
+		xpath:
+			"/rsm:CrossIndustryInvoice/rsm:ExchangedDocumentContext/ram:GuidelineSpecifiedDocumentContextParameter/ram:ID",
+	},
 	/**
 	 * Invoice number
 	 *

--- a/packages/node-zugferd/src/types/profile.ts
+++ b/packages/node-zugferd/src/types/profile.ts
@@ -6,7 +6,6 @@ export type Profile = {
 	id: LiteralString;
 	extends?: Profile[];
 	schema: Schema;
-	contextParameter: LiteralString;
 	xsdPath?: string;
 	conformanceLevel: string;
 	documentFileName: string;


### PR DESCRIPTION
- add field since it's a required element for all valid XRechnung documents
- see 302-XRechnung business rules BR-1

Disclaimer: I am not sure how that integrates with the xml generation since there seems to be a default specification id already by used. 