### PR TITLE
fix: add missing mask keys for BT-107 and BT-108

### DIFF
--- a/packages/node-zugferd/src/profiles/basic-wl/mask.ts
+++ b/packages/node-zugferd/src/profiles/basic-wl/mask.ts
@@ -251,8 +251,8 @@ export const basicWlMask = {
 						"BG-22",
 						{
 							lineTotalAmount: "BT-106",
-							chargeTotalAmount: "",
-							allowanceTotalAmount: "",
+							chargeTotalAmount: "BT-108",
+							allowanceTotalAmount: "BT-107",
 							taxBasisTotalAmount: "BT-109",
 							taxTotal: "BT-110",
 							grandTotalAmount: "BT-112",

--- a/packages/node-zugferd/src/profiles/basic/mask.ts
+++ b/packages/node-zugferd/src/profiles/basic/mask.ts
@@ -339,8 +339,8 @@ export const basicMask = {
 						"BG-22",
 						{
 							lineTotalAmount: "BT-106",
-							chargeTotalAmount: "",
-							allowanceTotalAmount: "",
+							chargeTotalAmount: "BT-108",
+							allowanceTotalAmount: "BT-107",
 							taxBasisTotalAmount: "BT-109",
 							taxTotal: "BT-110",
 							grandTotalAmount: "BT-112",

--- a/packages/node-zugferd/src/profiles/en16931/mask.ts
+++ b/packages/node-zugferd/src/profiles/en16931/mask.ts
@@ -454,8 +454,8 @@ export const en16931Mask = {
 						"BG-22",
 						{
 							lineTotalAmount: "BT-106",
-							chargeTotalAmount: "",
-							allowanceTotalAmount: "",
+							chargeTotalAmount: "BT-108",
+							allowanceTotalAmount: "BT-107",
 							taxBasisTotalAmount: "BT-109",
 							taxTotal: "BT-110",
 							roundingAmount: "BT-114",

--- a/packages/node-zugferd/src/profiles/extended/mask.ts
+++ b/packages/node-zugferd/src/profiles/extended/mask.ts
@@ -1319,8 +1319,8 @@ export const extendedMask = {
 						"BG-22",
 						{
 							lineTotalAmount: "BT-106",
-							chargeTotalAmount: "",
-							allowanceTotalAmount: "",
+							chargeTotalAmount: "BT-108",
+							allowanceTotalAmount: "BT-107",
 							taxBasisTotalAmount: "BT-109",
 							taxTotal: "BT-110",
 							roundingAmount: "BT-114",


### PR DESCRIPTION
closes #83 