### PR TITLE
fix: correct XSD element ordering for allowances and charges

### DIFF
--- a/packages/node-zugferd/src/formatter/xml/formatter.test.ts
+++ b/packages/node-zugferd/src/formatter/xml/formatter.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { EXTENDED } from "../../profiles";
+import { zugferd } from "../../zugferd";
+import type { ProfileExtended } from "../../profiles/extended";
+
+describe("XML Formatter", () => {
+	describe("CategoryTradeTax element ordering", () => {
+		it("should generate valid XML with charges containing categoryTradeTax", async () => {
+			const invoicer = zugferd({ profile: EXTENDED, strict: true });
+
+			const data = {
+				issueDate: new Date("2024-11-26"),
+				number: "INV-2024-001",
+				typeCode: "380",
+				transaction: {
+					line: [
+						{
+							identifier: "ITEM-001",
+							tradeProduct: { name: "Test Product" },
+							tradeAgreement: {
+								grossTradePrice: { chargeAmount: 100 },
+								netTradePrice: { chargeAmount: 100 },
+							},
+							tradeDelivery: {
+								billedQuantity: { amount: 1, unitMeasureCode: "C62" },
+							},
+							tradeSettlement: {
+								tradeTax: {
+									typeCode: "VAT",
+									categoryCode: "S",
+									rateApplicablePercent: 19,
+								},
+								monetarySummation: { lineTotalAmount: 100 },
+							},
+						},
+					],
+					tradeAgreement: {
+						seller: {
+							name: "Test Seller GmbH",
+							postalAddress: {
+								line1: "Test Street 1",
+								city: "Berlin",
+								postCode: "10115",
+								countryCode: "DE",
+							},
+							taxRegistration: { vatIdentifier: "DE123456789" },
+						},
+						buyer: {
+							name: "Test Buyer",
+							postalAddress: {
+								line1: "Buyer Street 1",
+								city: "Munich",
+								postCode: "80331",
+								countryCode: "DE",
+							},
+						},
+					},
+					tradeDelivery: {
+						information: { deliveryDate: new Date("2024-11-25") },
+					},
+					tradeSettlement: {
+						currencyCode: "EUR",
+						vatBreakdown: [
+							{
+								calculatedAmount: 20.88,
+								typeCode: "VAT",
+								basisAmount: 109.9,
+								categoryCode: "S",
+								rateApplicablePercent: 19,
+							},
+						],
+						charges: [
+							{
+								actualAmount: 9.9,
+								reason: "Shipping",
+								categoryTradeTax: {
+									typeCode: "VAT",
+									categoryCode: "S",
+									vatRate: 19,
+								},
+							},
+						],
+						monetarySummation: {
+							lineTotalAmount: 100,
+							chargeTotalAmount: 9.9,
+							allowanceTotalAmount: 0,
+							taxBasisTotalAmount: 109.9,
+							taxTotal: { amount: 20.88, currencyCode: "EUR" },
+							grandTotalAmount: 130.78,
+							duePayableAmount: 130.78,
+						},
+					},
+				},
+			};
+
+			const invoice = invoicer.create(data as ProfileExtended);
+
+			// This should not throw - XSD validation should pass
+			const xml = await invoice.toXML();
+
+			// Verify TypeCode comes before CategoryCode in CategoryTradeTax
+			const categoryTradeTaxMatch = xml.match(
+				/<ram:CategoryTradeTax>([\s\S]*?)<\/ram:CategoryTradeTax>/,
+			);
+			expect(categoryTradeTaxMatch).toBeTruthy();
+
+			const categoryTradeTaxContent = categoryTradeTaxMatch![1];
+			const typeCodeIndex = categoryTradeTaxContent.indexOf("<ram:TypeCode>");
+			const categoryCodeIndex =
+				categoryTradeTaxContent.indexOf("<ram:CategoryCode>");
+
+			expect(typeCodeIndex).toBeGreaterThan(-1);
+			expect(categoryCodeIndex).toBeGreaterThan(-1);
+			expect(typeCodeIndex).toBeLessThan(categoryCodeIndex);
+		});
+
+		it("should generate valid XML with allowances containing categoryTradeTax", async () => {
+			const invoicer = zugferd({ profile: EXTENDED, strict: true });
+
+			const data = {
+				issueDate: new Date("2024-11-26"),
+				number: "INV-2024-002",
+				typeCode: "380",
+				transaction: {
+					line: [
+						{
+							identifier: "ITEM-001",
+							tradeProduct: { name: "Test Product" },
+							tradeAgreement: {
+								grossTradePrice: { chargeAmount: 100 },
+								netTradePrice: { chargeAmount: 100 },
+							},
+							tradeDelivery: {
+								billedQuantity: { amount: 1, unitMeasureCode: "C62" },
+							},
+							tradeSettlement: {
+								tradeTax: {
+									typeCode: "VAT",
+									categoryCode: "S",
+									rateApplicablePercent: 19,
+								},
+								monetarySummation: { lineTotalAmount: 100 },
+							},
+						},
+					],
+					tradeAgreement: {
+						seller: {
+							name: "Test Seller GmbH",
+							postalAddress: {
+								line1: "Test Street 1",
+								city: "Berlin",
+								postCode: "10115",
+								countryCode: "DE",
+							},
+							taxRegistration: { vatIdentifier: "DE123456789" },
+						},
+						buyer: {
+							name: "Test Buyer",
+							postalAddress: {
+								line1: "Buyer Street 1",
+								city: "Munich",
+								postCode: "80331",
+								countryCode: "DE",
+							},
+						},
+					},
+					tradeDelivery: {
+						information: { deliveryDate: new Date("2024-11-25") },
+					},
+					tradeSettlement: {
+						currencyCode: "EUR",
+						vatBreakdown: [
+							{
+								calculatedAmount: 17.1,
+								typeCode: "VAT",
+								basisAmount: 90,
+								categoryCode: "S",
+								rateApplicablePercent: 19,
+							},
+						],
+						allowances: [
+							{
+								actualAmount: 10,
+								reason: "Discount",
+								categoryTradeTax: {
+									typeCode: "VAT",
+									categoryCode: "S",
+									vatRate: 19,
+								},
+							},
+						],
+						monetarySummation: {
+							lineTotalAmount: 100,
+							chargeTotalAmount: 0,
+							allowanceTotalAmount: 10,
+							taxBasisTotalAmount: 90,
+							taxTotal: { amount: 17.1, currencyCode: "EUR" },
+							grandTotalAmount: 107.1,
+							duePayableAmount: 107.1,
+						},
+					},
+				},
+			};
+
+			const invoice = invoicer.create(data as ProfileExtended);
+
+			// This should not throw - XSD validation should pass
+			const xml = await invoice.toXML();
+
+			// Verify TypeCode comes before CategoryCode in CategoryTradeTax
+			const categoryTradeTaxMatch = xml.match(
+				/<ram:CategoryTradeTax>([\s\S]*?)<\/ram:CategoryTradeTax>/,
+			);
+			expect(categoryTradeTaxMatch).toBeTruthy();
+
+			const categoryTradeTaxContent = categoryTradeTaxMatch![1];
+			const typeCodeIndex = categoryTradeTaxContent.indexOf("<ram:TypeCode>");
+			const categoryCodeIndex =
+				categoryTradeTaxContent.indexOf("<ram:CategoryCode>");
+
+			expect(typeCodeIndex).toBeGreaterThan(-1);
+			expect(categoryCodeIndex).toBeGreaterThan(-1);
+			expect(typeCodeIndex).toBeLessThan(categoryCodeIndex);
+		});
+	});
+});

--- a/packages/node-zugferd/src/profiles/basic-wl/mask.ts
+++ b/packages/node-zugferd/src/profiles/basic-wl/mask.ts
@@ -217,6 +217,7 @@ export const basicWlMask = {
 							categoryTradeTax: [
 								"BT-95-00",
 								{
+									typeCode: "BT-95-0",
 									categoryCode: "BT-95",
 									vatRate: "BT-96",
 								},
@@ -235,6 +236,7 @@ export const basicWlMask = {
 							categoryTradeTax: [
 								"BT-102-00",
 								{
+									typeCode: "BT-102-0",
 									categoryCode: "BT-102",
 									vatRate: "BT-103",
 								},

--- a/packages/node-zugferd/src/profiles/basic-wl/schema.ts
+++ b/packages/node-zugferd/src/profiles/basic-wl/schema.ts
@@ -2125,6 +2125,21 @@ BR-CO-21: Each Document level allowance (BG-20) shall contain a Document level a
 								required: false,
 								shape: {
 									/**
+									 * Document level allowance VAT type code
+									 *
+									 * Coded identification of the tax type. Fixed value "VAT".
+									 */
+									typeCode: {
+										key: "BT-95-0",
+										type: "string",
+										description: `**Document level allowance VAT type code**
+
+Coded identification of the tax type. Fixed value "VAT".`,
+										xpath:
+											"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge[allowances]/ram:CategoryTradeTax/ram:TypeCode",
+										defaultValue: "VAT",
+									},
+									/**
 									 * Document level allowance VAT category code
 									 *
 									 * A coded identification of what VAT category applies to the document level allowance.
@@ -2204,15 +2219,6 @@ The value to enter is the percentage. For example, for 20%, it must be given as 
 										required: false,
 										xpath:
 											"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge[allowances]/ram:CategoryTradeTax/ram:RateApplicablePercent",
-									},
-								},
-								additionalXml: {
-									typeCode: {
-										key: "BT-95-0",
-										type: "string",
-										xpath:
-											"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge[allowances]/ram:CategoryTradeTax/ram:TypeCode",
-										defaultValue: "VAT",
 									},
 								},
 							},
@@ -2381,6 +2387,21 @@ A finite sequence of characters.`,
 								required: false,
 								shape: {
 									/**
+									 * Document level charge VAT type code
+									 *
+									 * Coded identification of the tax type. Fixed value "VAT".
+									 */
+									typeCode: {
+										key: "BT-102-0",
+										type: "string",
+										description: `**Document level charge VAT type code**
+
+Coded identification of the tax type. Fixed value "VAT".`,
+										xpath:
+											"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge[charges]/ram:CategoryTradeTax/ram:TypeCode",
+										defaultValue: "VAT",
+									},
+									/**
 									 * Document level charge VAT category code
 									 *
 									 * A coded identification of what VAT category applies to the document level charge.
@@ -2460,15 +2481,6 @@ The value to enter is the percentage. For example, for 20%, it must be given as 
 										required: false,
 										xpath:
 											"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge[charges]/ram:CategoryTradeTax/ram:RateApplicablePercent",
-									},
-								},
-								additionalXml: {
-									typeCode: {
-										key: "BT-102-0",
-										type: "string",
-										xpath:
-											"/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeAllowanceCharge[charges]/ram:CategoryTradeTax/ram:TypeCode",
-										defaultValue: "VAT",
 									},
 								},
 							},

--- a/packages/node-zugferd/src/profiles/basic/mask.ts
+++ b/packages/node-zugferd/src/profiles/basic/mask.ts
@@ -308,6 +308,7 @@ export const basicMask = {
 							categoryTradeTax: [
 								"BT-95-00",
 								{
+									typeCode: "BT-95-0",
 									categoryCode: "BT-95",
 									vatRate: "BT-96",
 								},
@@ -326,6 +327,7 @@ export const basicMask = {
 							categoryTradeTax: [
 								"BT-102-00",
 								{
+									typeCode: "BT-102-0",
 									categoryCode: "BT-102",
 									vatRate: "BT-103",
 								},

--- a/packages/node-zugferd/src/profiles/en16931/mask.ts
+++ b/packages/node-zugferd/src/profiles/en16931/mask.ts
@@ -423,6 +423,7 @@ export const en16931Mask = {
 							categoryTradeTax: [
 								"BT-95-00",
 								{
+									typeCode: "BT-95-0",
 									categoryCode: "BT-95",
 									vatRate: "BT-96",
 								},
@@ -441,6 +442,7 @@ export const en16931Mask = {
 							categoryTradeTax: [
 								"BT-102-00",
 								{
+									typeCode: "BT-102-0",
 									categoryCode: "BT-102",
 									vatRate: "BT-103",
 								},

--- a/packages/node-zugferd/src/profiles/extended/mask.ts
+++ b/packages/node-zugferd/src/profiles/extended/mask.ts
@@ -1192,6 +1192,7 @@ export const extendedMask = {
 							categoryTradeTax: [
 								"BT-95-00",
 								{
+									typeCode: "BT-95-0",
 									categoryCode: "BT-95",
 									vatRate: "BT-96",
 								},
@@ -1212,6 +1213,7 @@ export const extendedMask = {
 							categoryTradeTax: [
 								"BT-102-00",
 								{
+									typeCode: "BT-102-0",
 									categoryCode: "BT-102",
 									vatRate: "BT-103",
 								},


### PR DESCRIPTION
Hi and thank you for your work on this project!

I have faced an issue today that the extended profile generates the TypeCode after other parameters in the allowances and charges and fails XSD validation. See below

```
<ram:ApplicableHeaderTradeSettlement>
      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
      <ram:SpecifiedTradeSettlementPaymentMeans>
        <ram:TypeCode>58</ram:TypeCode>
        <ram:PayeePartyCreditorFinancialAccount>
          <ram:IBANID>...</ram:IBANID>
        </ram:PayeePartyCreditorFinancialAccount>
      </ram:SpecifiedTradeSettlementPaymentMeans>
      <ram:ApplicableTradeTax>
        <ram:CalculatedAmount>1657.56</ram:CalculatedAmount>
        <ram:TypeCode>VAT</ram:TypeCode>
        <ram:BasisAmount>8724</ram:BasisAmount>
        <ram:CategoryCode>S</ram:CategoryCode>
        <ram:RateApplicablePercent>19</ram:RateApplicablePercent>
      </ram:ApplicableTradeTax>
      <ram:SpecifiedTradeAllowanceCharge>
        <ram:ChargeIndicator>
          <udt:Indicator>true</udt:Indicator>
        </ram:ChargeIndicator>
        <ram:ActualAmount>49.9</ram:ActualAmount>
        <ram:Reason>Speditionsversand</ram:Reason>
        <ram:CategoryTradeTax>
          <ram:CategoryCode>S</ram:CategoryCode>
          <ram:RateApplicablePercent>19</ram:RateApplicablePercent>
          <ram:TypeCode>VAT</ram:TypeCode>
        </ram:CategoryTradeTax>
      </ram:SpecifiedTradeAllowanceCharge>
      <ram:SpecifiedTradePaymentTerms>
        <ram:DueDateDateTime>
          <udt:DateTimeString format="102">20241226</udt:DateTimeString>
        </ram:DueDateDateTime>
      </ram:SpecifiedTradePaymentTerms>
      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
        <ram:LineTotalAmount>8724</ram:LineTotalAmount>
        <ram:ChargeTotalAmount>49.9</ram:ChargeTotalAmount>
        <ram:AllowanceTotalAmount>436.2</ram:AllowanceTotalAmount>
        <ram:TaxBasisTotalAmount>8337.699999999999</ram:TaxBasisTotalAmount>
        <ram:TaxTotalAmount currencyID="EUR">1657.56</ram:TaxTotalAmount>
        <ram:GrandTotalAmount>9995.26</ram:GrandTotalAmount>
        <ram:DuePayableAmount>9995.26</ram:DuePayableAmount>
      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
    </ram:ApplicableHeaderTradeSettlement>
```
Minimal repro:

```ts
// minimal-repro.ts - ZUGFeRD XML element ordering bug

import { zugferd } from 'node-zugferd';
import { EXTENDED } from 'node-zugferd/profile/extended';

const invoicer = zugferd({ profile: EXTENDED, strict: true });

const data = {
  issueDate: '2024-11-26',
  number: 'INV-2024-001',
  typeCode: '380',
  transaction: {
    line: [
      {
        identifier: 'ITEM-001',
        tradeProduct: { name: 'Test Product' },
        tradeAgreement: {
          grossTradePrice: { chargeAmount: 100 },
          netTradePrice: { chargeAmount: 100 },
        },
        tradeDelivery: {
          billedQuantity: { amount: 1, unitMeasureCode: 'C62' },
        },
        tradeSettlement: {
          tradeTax: {
            typeCode: 'VAT',
            categoryCode: 'S',
            rateApplicablePercent: 19,
          },
          monetarySummation: { lineTotalAmount: 100 },
        },
      },
    ],
    tradeAgreement: {
      seller: {
        name: 'Test Seller GmbH',
        postalAddress: {
          line1: 'Test Street 1',
          city: 'Berlin',
          postCode: '10115',
          countryCode: 'DE',
        },
        taxRegistration: { vatIdentifier: 'DE123456789' },
      },
      buyer: {
        name: 'Test Buyer',
        postalAddress: {
          line1: 'Buyer Street 1',
          city: 'Munich',
          postCode: '80331',
          countryCode: 'DE',
        },
      },
    },
    tradeDelivery: {
      information: { deliveryDate: '2024-11-25' },
    },
    tradeSettlement: {
      currencyCode: 'EUR',
      vatBreakdown: [
        {
          calculatedAmount: 19,
          typeCode: 'VAT',
          basisAmount: 100,
          categoryCode: 'S',
          rateApplicablePercent: 19,
        },
      ],
      // THIS CAUSES THE BUG - charges with categoryTradeTax
      charges: [
        {
          actualAmount: 9.9,
          reason: 'Shipping',
          categoryTradeTax: {
            categoryCode: 'S',
            vatRate: 19,
          },
        },
      ],
      monetarySummation: {
        lineTotalAmount: 100,
        chargeTotalAmount: 9.9,
        allowanceTotalAmount: 0,
        taxBasisTotalAmount: 109.9,
        taxTotal: { amount: 20.88, currencyCode: 'EUR' },
        grandTotalAmount: 130.78,
        duePayableAmount: 130.78,
      },
    },
  },
} satisfies typeof invoicer.$Infer.Schema;

async function main() {
  const invoice = invoicer.create(data);
  const xml = await invoice.toXML();
  console.log(xml);
}

main().catch(console.error);
```

The fix I found works well, not sure however how does it fit into the whole project architecture and idea.