### PR TITLE
fix: PDF/A-3 metadata and ICC profile validation errors

### DIFF
--- a/packages/node-zugferd/src/document/create.ts
+++ b/packages/node-zugferd/src/document/create.ts
@@ -43,7 +43,9 @@ export const createDocumentFactory =
 			metadata.modifyDate ??= metadata.createDate;
 
 			let pdfDoc =
-				pdf instanceof PDFDocument ? pdf : await PDFDocument.load(pdf);
+				pdf instanceof PDFDocument
+					? pdf
+					: await PDFDocument.load(pdf, { updateMetadata: false });
 
 			ctx.logger.debug(
 				`[${embedInPdf.name}] Attaching ${colors.bright}${profile.documentFileName}${colors.reset}`,
@@ -122,7 +124,7 @@ export const createDocumentFactory =
 			}
 
 			ctx.logger.debug(`[${embedInPdf.name}] Saving PDF`);
-			return await pdfDoc.save();
+			return await pdfDoc.save({ useObjectStreams: false });
 		};
 
 		return {


### PR DESCRIPTION
## Summary

Fixes PDF/A-3B validation errors reported by the official Factur-X validator at https://services.fnfe-mpe.org/. PDFs generated by `embedInPdf` now pass both PDF and XML validation. Relates to #110.

## Root Cause

The XMP metadata stream contained `xmlns:about=""` (an empty XML namespace declaration), which is **forbidden by the XML Namespace specification**. This caused every strict XML parser — including the PDF/A validator — to reject the entire XMP document. The validator then:
1. Could not read `pdfaid:part=3`, so it defaulted to testing as PDF/A-1b
2. Reported all XMP metadata fields as `null`
3. Failed EmbeddedFiles checks (forbidden in PDF/A-1, allowed in PDF/A-3)

This single typo (`xmlns:about` instead of `rdf:about`) was the root cause of all reported PDF validation errors.

## Changes

### 1. Fix invalid `xmlns:about=""` → `rdf:about=""` (formatter.ts)

The Factur-X `rdf:Description` block for `fx:DocumentType` etc. used `@xmlns:about` which generates `xmlns:about=""` — an empty namespace, invalid XML. Changed to `@rdf:about` which generates the correct `rdf:about=""` attribute.

**This was the critical fix** that made the entire XMP parseable.

### 2. Add `dc:title` and `dc:description` to XMP metadata (formatter.ts)

The Info dictionary fields Title and Subject (set via `setTitle`/`setSubject`) had no corresponding XMP entries, causing metadata mismatch errors. Now included with correct `rdf:Alt` / `xml:lang="x-default"` structure per XMP spec.

### 3. Fix `dc:creator` to use `metadata.author` (formatter.ts)

`dc:creator` was set to `metadata.creator`, but per PDF/XMP spec:
- `dc:creator` must match Info `/Author` (= `metadata.author`)
- `xmp:CreatorTool` must match Info `/Creator` (= `metadata.creator`)

Falls back to `metadata.creator` when author is not provided.

### 4. Encode XMP as UTF-8 bytes (formatter.ts)

The XMP string was passed directly to `context.stream()` with `Length: xmp.length`. JavaScript's `.length` counts UTF-16 code units, but the PDF stream contains UTF-8 bytes. The `\uFEFF` BOM (1 JS char → 3 UTF-8 bytes) caused a length mismatch that made validators fail to read the stream. Now uses `TextEncoder().encode()` for correct byte-level handling.

### 5. Add `N: 3` to ICC profile stream (formatter.ts)

The sRGB ICC profile stream was missing the required `N` entry (number of color components), causing: *"The N entry (value null) does not match the number of components in the embedded ICC profile (color space RGB)"*

### 6. Load PDF with `updateMetadata: false` (create.ts)

`PDFDocument.load()` defaults to `updateMetadata: true`, which auto-sets `Producer = "pdf-lib"` and `Creator = "pdf-lib"` in the Info dictionary before `embedInPdf` can set the correct values. Now disabled to prevent stale metadata.

### 7. Save with `useObjectStreams: false` (create.ts)

Forces traditional cross-reference tables instead of xref streams for maximum PDF/A compatibility.

## Validation Results

Before (from issue #110):
```
PDF: Not a PDF/A-3 (13 errors)
XML: valid
```

After:
```
PDF: flavour=3b, isCompliant=true, assertions=[] (0 errors)
XML: valid (32 rules fired, 0 failed, 8 XRechnung-specific notices)
```

Tested with Puppeteer-generated PDFs validated against the official Factur-X validator.

## Test plan

- [x] Existing tests pass (2 pre-existing XSD validation failures in `formatter.test.ts` unrelated — require Java)
- [x] Generated PDFs validated at https://services.fnfe-mpe.org/ — PDF/A-3B compliant, XML valid
- [x] Tested with BASIC profile, real invoice data, EU reverse charge scenario