### PR TITLE
fix: correct Factur-X XMP attribute and CII element ordering in merged profiles

### DIFF
--- a/packages/node-zugferd/src/formatter/xml/formatter.ts
+++ b/packages/node-zugferd/src/formatter/xml/formatter.ts
@@ -104,7 +104,10 @@ const reorderSchema = (schema: Schema, reference: Schema): Schema => {
 			const field = schema[key];
 			const refField = reference[key];
 			if (field.shape && refField.shape) {
-				result[key] = { ...field, shape: reorderSchema(field.shape, refField.shape) };
+				result[key] = {
+					...field,
+					shape: reorderSchema(field.shape, refField.shape),
+				};
 			} else {
 				result[key] = field;
 			}
@@ -143,7 +146,9 @@ export const mergeSchemas = (profile: Profile): Schema => {
 	// producing invalid CII XML element ordering.
 	const reorderedSchema = reorderSchema(mergedSchema, mergedExtensions);
 
-	return profile.mask ? applyMask(reorderedSchema, profile.mask) : reorderedSchema;
+	return profile.mask
+		? applyMask(reorderedSchema, profile.mask)
+		: reorderedSchema;
 };
 
 export type ParseSchemaOptions = {


### PR DESCRIPTION
## Summary                                                

  - Fix `xmlns:about=""` → `rdf:about=""` in the Factur-X `rdf:Description` XMP metadata, which prevented validators (KoSIT, sevDesk) from discovering the embedded XML attachment
  - Fix CII XML element ordering when profile schemas are merged via `defu`, which produced invalid element sequences for profiles that extend BASIC (EN16931, EXTENDED)

  ## Details

  ### 1. Factur-X XMP `rdf:about` attribute (`formatter/pdf`)

  The Factur-X `rdf:Description` block used `xmlns:about=""` which declares an invalid XML namespace prefix instead of the correct `rdf:about=""` RDF resource identifier. Validators parse XMP/RDF to locate the Factur-X XML attachment filename — this malformed attribute caused them to fail, even though the XML was
  correctly embedded via `/Names/EmbeddedFiles` and `/AF`.

  Note: #111 fixed the other `rdf:Description` blocks but missed this Factur-X-specific one.

  ### 2. Schema merge key ordering (`formatter/xml`)

  `mergeSchemas` uses `defu({}, mergedExtensions, profile.schema)` to combine base and extending profile schemas. Internally, `defu` clones the last argument first via `Object.assign({}, defaults)`, giving its key order priority. When the extending profile (e.g. EN16931) only defines a subset of keys
  (`tradeProduct`, `tradeAgreement`, `tradeSettlement`), base-only keys (`identifier`, `note`, `tradeDelivery`) get appended at the end instead of their correct CII position.

  This adds a `reorderSchema` post-processing step that walks the merged schema tree and reorders keys to match the base profiles' element sequence.

  ## Test plan

  - [x] All existing tests pass (19/19 across both packages)
  - [ ] Generate a PDF with EN16931 profile and validate with KoSIT validator
  - [ ] Verify Factur-X XML attachment is discoverable via XMP metadata