### PR TITLE
feat: add @node-zugferd/pdf plugin for programmatic PDF generation

### DIFF
--- a/docs/content/docs/plugins/pdf.mdx
+++ b/docs/content/docs/plugins/pdf.mdx
@@ -1,0 +1,231 @@
+---
+title: PDF
+description: Generate complete e-invoices programmatically — data in, PDF/A-3b out.
+---
+
+## Features
+
+- **One call**: `createPdf(data)` renders the PDF, generates the Factur-X XML, embeds it and returns a finished PDF/A-3b document
+- **Built-in template** for a German business invoice (DIN 5008 inspired) rendering all content required by § 14 Abs. 4 UStG
+- **Lightweight**: pure JavaScript rendering via [pdfmake](https://pdfmake.github.io/docs/) — no headless browser, works on serverless platforms
+- **Customizable**: from a logo and colors over label overrides up to fully custom templates
+- **PDF/A-safe**: fonts are always embedded, the output passes [veraPDF](https://verapdf.org) PDF/A-3b validation
+
+<Callout>Looking for HTML/CSS templates rendered by your favorite frontend
+framework? That's what the [API Plugin](/docs/plugins/api) is for. This plugin
+optimizes for zero-setup programmatic generation instead.</Callout>
+
+## Installation
+
+<Steps>
+
+<Step>
+
+### Install the package
+
+```package-install
+@node-zugferd/pdf
+```
+
+</Step>
+
+<Step>
+
+### Add the plugin
+
+Register the plugin on your zugferd instance and pick a template. The built-in
+`defaultTemplate` works out of the box — all of its options are optional.
+
+```ts title="invoicer.ts"
+import { zugferd } from "node-zugferd";
+import { EN16931 } from "node-zugferd/profile/en16931";
+import { pdf } from "@node-zugferd/pdf";
+import { defaultTemplate } from "@node-zugferd/pdf/templates";
+
+export const invoicer = zugferd({
+  profile: EN16931,
+  plugins: [
+    pdf({
+      template: defaultTemplate(),
+    }),
+  ],
+});
+```
+
+</Step>
+
+<Step>
+
+### &#x1F389; That's it!
+
+Pass your invoice data and get a finished e-invoice back — a PDF/A-3b document
+with the validated Factur-X XML embedded.
+
+```ts
+const data: typeof invoicer.$Infer.Schema = {
+  //... your data
+};
+
+const pdfA = await invoicer.createPdf(data, {
+  metadata: {
+    title: "Rechnung 471102",
+  },
+});
+```
+
+</Step>
+
+</Steps>
+
+<Callout type="warn">The default template requires at least one invoice line
+and therefore the **BASIC profile or higher**. Documents of the MINIMUM and
+BASIC WL profiles are not considered invoices under German fiscal law anyway —
+if you need to render them, provide a [custom template](#fully-custom-templates).</Callout>
+
+## The default template
+
+The built-in template produces a classic German business invoice: sender line
+and recipient address field, a document meta block (invoice number, dates,
+customer number, service period, VAT ID or tax number), the line item table
+with automatic page breaks, a totals block including the VAT breakdown, notes
+and payment terms, and a footer repeated on every page.
+
+Everything is rendered **exclusively from the data you pass to `createPdf`** —
+the same data the XML is generated from, so the visible PDF can never
+contradict the embedded XML.
+
+```ts
+defaultTemplate({
+  // PNG or JPEG, rendered in the top right corner
+  logo: fs.readFileSync("./logo.png"),
+  logoWidth: 140,
+  // color used for table rules and emphasis
+  accentColor: "#1e3a5f",
+  // DIN 5008 sender line, derived from the seller data by default
+  senderLine: "Lieferant GmbH · Lieferantenstraße 20 · 80333 München",
+  // footer columns repeated on every page — use them for the mandatory
+  // German business details
+  footer: {
+    columns: [
+      "Lieferant GmbH\nLieferantenstraße 20\n80333 München",
+      "Geschäftsführer: Hans Muster\nAmtsgericht München HRB 12345",
+      "IBAN: DE02 1203 0000 0000 2020 51\nBIC: BYLADEM1001",
+    ],
+  },
+});
+```
+
+### Labels
+
+All labels ship in German and can be overridden individually — for example to
+generate an English invoice:
+
+```ts
+defaultTemplate({
+  labels: {
+    invoiceTitle: "Invoice No.",
+    invoiceDate: "Invoice date",
+    deliveryDate: "Delivery date",
+    // ...
+  },
+});
+```
+
+Number and date formatting follows the plugin's `intlLocale` option (default
+`"de-DE"`):
+
+```ts
+pdf({
+  template: defaultTemplate(),
+  intlLocale: "en-US",
+});
+```
+
+## Custom fonts
+
+PDF/A-3 requires every font to be embedded, so the plugin never uses the 14
+standard PDF fonts. By default it embeds the Roboto family that ships with
+pdfmake. To use your own font, provide TTF buffers — the first family becomes
+the document's default font:
+
+```ts
+pdf({
+  template: defaultTemplate(),
+  fonts: {
+    Inter: {
+      normal: fs.readFileSync("./fonts/Inter-Regular.ttf"),
+      bold: fs.readFileSync("./fonts/Inter-Bold.ttf"),
+      italics: fs.readFileSync("./fonts/Inter-Italic.ttf"),
+      bolditalics: fs.readFileSync("./fonts/Inter-BoldItalic.ttf"),
+    },
+  },
+});
+```
+
+## Fully custom templates
+
+A template is any function that turns invoice data into a
+[pdfmake document definition](https://pdfmake.github.io/docs/document-definition-object/) —
+`defaultTemplate` is just one implementation. Your template receives the
+invoice data, a logger and locale-aware formatters:
+
+```ts title="my-template.ts"
+import type { InvoiceTemplate } from "@node-zugferd/pdf";
+
+export const myTemplate: InvoiceTemplate = ({ data, formatters }) => ({
+  pageSize: "A4",
+  content: [
+    { text: `Invoice ${data.number}`, fontSize: 16, bold: true },
+    { text: formatters.date(data.issueDate) },
+    // ...
+    {
+      text: formatters.currency(
+        data.transaction.tradeSettlement.monetarySummation.grandTotalAmount,
+        data.transaction.tradeSettlement.currencyCode,
+      ),
+    },
+  ],
+});
+```
+
+```ts title="invoicer.ts"
+pdf({ template: myTemplate });
+```
+
+<Callout type="warn">A Factur-X hybrid document must show the same information
+as its embedded XML. Render your template from the invoice data only, and make
+sure everything the XML contains is visible on the PDF.</Callout>
+
+## Options
+
+### `pdf()`
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `template` | `InvoiceTemplate` | **Required.** Turns invoice data into a pdfmake document definition. |
+| `intlLocale` | `string` | BCP 47 locale for the built-in formatters. Defaults to `"de-DE"`. |
+| `fonts` | `Record<string, PdfFont>` | Custom fonts (TTF buffers), keyed by family name. Defaults to the bundled Roboto family. |
+
+### `createPdf(data, options?)`
+
+`data` must match the schema of your configured profile
+(`typeof invoicer.$Infer.Schema`). The options are passed through to
+[`embedInPdf`](/docs/basic-usage):
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `metadata` | `object` | PDF metadata (title, author, subject, keywords, …). |
+| `additionalFiles` | `array` | Additional attachments to embed alongside the Factur-X XML. |
+
+Returns the finished PDF/A-3b document as a `Uint8Array`.
+
+### `defaultTemplate()`
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `logo` | `Buffer \| Uint8Array \| string` | Logo (PNG/JPEG) for the top right corner. |
+| `logoWidth` | `number` | Logo width in pt. Defaults to `140`. |
+| `accentColor` | `string` | Color for table rules and emphasis. Defaults to `"#333333"`. |
+| `senderLine` | `string` | DIN 5008 sender line above the address field. Derived from the seller by default. |
+| `footer` | `{ columns: string[] }` | Footer columns repeated on every page. |
+| `labels` | `object` | Overrides for the built-in German label set. |

--- a/docs/src/data/sidebar-items/index.tsx
+++ b/docs/src/data/sidebar-items/index.tsx
@@ -5,6 +5,7 @@ import {
 	BookOpenIcon,
 	ChartColumn,
 	CirclePlayIcon,
+	FileTextIcon,
 	GitPullRequestCreateArrowIcon,
 	LayoutGridIcon,
 	LibraryIcon,
@@ -119,6 +120,11 @@ export const contents: Content[] = [
 						<path d="M9 12v-6.5a2.5 2.5 0 0 1 5 0v.5" />
 					</svg>
 				),
+			},
+			{
+				title: "PDF",
+				href: "/docs/plugins/pdf",
+				Icon: FileTextIcon,
 			},
 		],
 	},

--- a/packages/pdf/README.md
+++ b/packages/pdf/README.md
@@ -1,0 +1,77 @@
+<h1 align="center">@node-zugferd/pdf</h1>
+
+Programmatic PDF generation for [node-zugferd](https://github.com/jslno/node-zugferd):
+pass your invoice data, get a finished e-invoice back — a PDF/A-3b document
+with the validated Factur-X XML embedded. No headless browser, no server
+required.
+
+Ships with a built-in, customizable template for a German business invoice
+(DIN 5008 inspired) that renders all content required by § 14 Abs. 4 UStG.
+
+## Installation
+
+```bash
+npm install @node-zugferd/pdf@latest
+```
+
+## Usage
+
+```ts
+import { zugferd } from "node-zugferd";
+import { EN16931 } from "node-zugferd/profile/en16931";
+import { pdf } from "@node-zugferd/pdf";
+import { defaultTemplate } from "@node-zugferd/pdf/templates";
+
+const invoicer = zugferd({
+  profile: EN16931,
+  plugins: [
+    pdf({
+      template: defaultTemplate({
+        logo: fs.readFileSync("./logo.png"),
+        accentColor: "#1e3a5f",
+        footer: {
+          columns: [
+            "Lieferant GmbH\nLieferantenstraße 20\n80333 München",
+            "Geschäftsführer: Hans Muster\nAmtsgericht München HRB 12345",
+            "IBAN: DE02 1203 0000 0000 2020 51\nBIC: BYLADEM1001",
+          ],
+        },
+      }),
+    }),
+  ],
+});
+
+const data: typeof invoicer.$Infer.Schema = {
+  //... your data
+};
+
+const pdfA = await invoicer.createPdf(data, {
+  metadata: {
+    title: "Rechnung 471102",
+  },
+});
+```
+
+Rendering is done with [pdfmake](https://pdfmake.github.io/docs/) (pure
+JavaScript, automatic page breaks). Fonts are always embedded, as required by
+PDF/A — the output passes [veraPDF](https://verapdf.org) PDF/A-3b validation.
+
+Templates are fully replaceable: any function returning a pdfmake document
+definition works.
+
+```ts
+import type { InvoiceTemplate } from "@node-zugferd/pdf";
+
+const myTemplate: InvoiceTemplate = ({ data, formatters }) => ({
+  content: [{ text: `Invoice ${data.number}` }],
+});
+```
+
+## Documentation
+
+See the [PDF plugin documentation](https://node-zugferd.jsolano.de/docs/plugins/pdf)
+for all options, custom fonts, label overrides and custom templates.
+
+## License
+
+Distributed under the MIT License. See LICENSE.md for more information.

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -1,0 +1,76 @@
+{
+	"name": "@node-zugferd/pdf",
+	"version": "0.1.1-beta.1",
+	"description": "Programmatic PDF generation for node-zugferd. Renders invoices from a built-in, customizable template and returns finished PDF/A-3b documents with embedded Factur-X XML.",
+	"type": "module",
+	"scripts": {
+		"build": "tsup --clean --dts",
+		"dev": "tsup --watch --sourcemap",
+		"dev:dts": "tsup --watch --dts",
+		"test": "vitest",
+		"typecheck": "tsc --noEmit"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"keywords": [
+		"zugferd",
+		"factur-x",
+		"invoice",
+		"pdf",
+		"pdfa",
+		"e-invoice",
+		"electronic-invoice",
+		"invoice-generation",
+		"pdf-invoice",
+		"invoice-template"
+	],
+	"author": "Joél de Oliveira Solano da Silva",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/jslno/node-zugferd.git",
+		"directory": "packages/pdf"
+	},
+	"homepage": "https://node-zugferd.jsolano.de",
+	"license": "MIT",
+	"devDependencies": {
+		"@biomejs/biome": "1.9.4",
+		"@types/node": "^22.10.7",
+		"@types/pdfmake": "^0.2.11",
+		"pdf-lib": "^1.17.1",
+		"tsup": "^8.3.5",
+		"typescript": "^5.7.3",
+		"vitest": "^3.0.4"
+	},
+	"dependencies": {
+		"node-zugferd": "workspace:*",
+		"pdfmake": "^0.2.20"
+	},
+	"main": "./dist/index.js",
+	"module": "./dist/index.mjs",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
+		},
+		"./templates": {
+			"import": {
+				"types": "./dist/templates.d.ts",
+				"default": "./dist/templates.js"
+			},
+			"require": {
+				"types": "./dist/templates.d.cts",
+				"default": "./dist/templates.cjs"
+			}
+		}
+	},
+	"files": [
+		"dist"
+	]
+}

--- a/packages/pdf/src/fonts.ts
+++ b/packages/pdf/src/fonts.ts
@@ -1,0 +1,38 @@
+import type { PdfFont } from "./types";
+
+/**
+ * PDF/A-3 forbids non-embedded fonts, so pdfmake's "standard 14 fonts"
+ * path (Helvetica etc.) must never be used. Instead the Roboto family that
+ * pdfmake already ships for the browser (as base64 in its virtual file
+ * system) is reused server-side and embedded into the document.
+ */
+export const getDefaultFonts = async (): Promise<Record<string, PdfFont>> => {
+	const vfsModule: any = await import("pdfmake/build/vfs_fonts.js");
+
+	// the export shape changed across pdfmake 0.2.x releases
+	const vfs: Record<string, string> =
+		vfsModule.pdfMake?.vfs ??
+		vfsModule.vfs ??
+		vfsModule.default?.pdfMake?.vfs ??
+		vfsModule.default ??
+		vfsModule;
+
+	const read = (file: string) => {
+		const data = vfs[file];
+		if (typeof data !== "string") {
+			throw new Error(
+				`[@node-zugferd/pdf] Could not load bundled font "${file}" from pdfmake. Provide your own fonts via the plugin's "fonts" option.`,
+			);
+		}
+		return Buffer.from(data, "base64");
+	};
+
+	return {
+		Roboto: {
+			normal: read("Roboto-Regular.ttf"),
+			bold: read("Roboto-Medium.ttf"),
+			italics: read("Roboto-Italic.ttf"),
+			bolditalics: read("Roboto-MediumItalic.ttf"),
+		},
+	};
+};

--- a/packages/pdf/src/index.ts
+++ b/packages/pdf/src/index.ts
@@ -1,0 +1,12 @@
+export { pdf } from "./plugin";
+export { renderPdf } from "./renderer";
+export { getDefaultFonts } from "./fonts";
+export { createFormatters } from "./utils/format";
+export type {
+	CreatePdfOptions,
+	Formatters,
+	InvoiceTemplate,
+	PdfFont,
+	PdfPluginOptions,
+	TemplateContext,
+} from "./types";

--- a/packages/pdf/src/plugin.test.ts
+++ b/packages/pdf/src/plugin.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { zugferd } from "node-zugferd";
+import { BASIC } from "node-zugferd/profile/basic";
+import { EN16931 } from "node-zugferd/profile/en16931";
+import { PDFDocument } from "pdf-lib";
+import { pdf } from "./plugin";
+import { defaultTemplate } from "./templates";
+import type { InvoiceTemplate } from "./types";
+import { isPdfA3b } from "./test-utils/pdf";
+import { findVeraPdf, validatePdfA3b } from "./test-utils/verapdf";
+import basicData from "./test-utils/data/basic";
+import en16931Data from "./test-utils/data/en16931";
+
+const getInvoicer = (template: InvoiceTemplate = defaultTemplate()) =>
+	zugferd({
+		profile: BASIC,
+		logger: { disabled: true },
+		plugins: [pdf({ template })],
+	});
+
+describe("pdf plugin", () => {
+	it("registers a createPdf handler", () => {
+		const invoicer = getInvoicer();
+		expect(invoicer.createPdf).toBeTypeOf("function");
+	});
+
+	it("creates a PDF/A-3b document with the Factur-X XML embedded", async () => {
+		const invoicer = getInvoicer(
+			defaultTemplate({
+				footer: {
+					columns: [
+						"Lieferant GmbH\nLieferantenstraße 20\n80333 München",
+						"Geschäftsführer: Hans Muster\nHandelsregisternummer: H A 123",
+					],
+				},
+			}),
+		);
+		const pdfA = await invoicer.createPdf(basicData, {
+			metadata: { title: "Rechnung 471102" },
+		});
+
+		expect(pdfA).toBeInstanceOf(Uint8Array);
+		expect(isPdfA3b(pdfA)).toBe(true);
+
+		const doc = await PDFDocument.load(pdfA);
+		expect(doc.getTitle()).toBe("Rechnung 471102");
+
+		const attachments = invoicer.context.pdf.getAttachments(doc);
+		const facturXFile = attachments.find(
+			(val) => val.name === BASIC.documentFileName,
+		);
+		expect(facturXFile).toBeDefined();
+
+		const facturX = new TextDecoder("utf-8").decode(facturXFile?.data);
+		expect(facturX).toEqual(await invoicer.create(basicData).toXML());
+	});
+
+	it("supports the EN 16931 profile", async () => {
+		const invoicer = zugferd({
+			profile: EN16931,
+			logger: { disabled: true },
+			plugins: [pdf({ template: defaultTemplate() })],
+		});
+		const pdfA = await invoicer.createPdf(en16931Data);
+
+		expect(isPdfA3b(pdfA)).toBe(true);
+
+		const doc = await PDFDocument.load(pdfA);
+		const attachments = invoicer.context.pdf.getAttachments(doc);
+		expect(
+			attachments.some((val) => val.name === EN16931.documentFileName),
+		).toBe(true);
+	});
+
+	it("breaks long line item tables across pages", async () => {
+		const invoicer = getInvoicer();
+		const line = basicData.transaction.line[0]!;
+		const pdfA = await invoicer.createPdf({
+			...basicData,
+			transaction: {
+				...basicData.transaction,
+				line: Array.from({ length: 60 }, (_, i) => ({
+					...line,
+					identifier: String(i + 1),
+				})),
+			},
+		});
+
+		const doc = await PDFDocument.load(pdfA);
+		expect(doc.getPageCount()).toBeGreaterThan(1);
+	});
+
+	it("uses a fully custom template", async () => {
+		const template = vi.fn<InvoiceTemplate>((ctx) => ({
+			content: [{ text: `Invoice ${ctx.data.number}` }],
+		}));
+		const invoicer = getInvoicer(template);
+		const pdfA = await invoicer.createPdf(basicData);
+
+		expect(template).toHaveBeenCalledOnce();
+		expect(template.mock.calls[0]?.[0]).toMatchObject({
+			data: basicData,
+		});
+		expect(template.mock.calls[0]?.[0]?.formatters.currency).toBeTypeOf(
+			"function",
+		);
+		expect(isPdfA3b(pdfA)).toBe(true);
+	});
+});
+
+describe("defaultTemplate", () => {
+	it("throws a descriptive error when the profile provides no lines", async () => {
+		const invoicer = getInvoicer();
+		await expect(
+			invoicer.createPdf({ ...basicData, transaction: undefined }),
+		).rejects.toThrow(/requires at least one invoice line/);
+	});
+});
+
+describe("PDF/A-3b conformance (veraPDF)", async () => {
+	const verapdf = await findVeraPdf();
+
+	it.skipIf(!verapdf)(
+		"produces a document that passes veraPDF validation",
+		async () => {
+			const invoicer = getInvoicer();
+			const pdfA = await invoicer.createPdf(basicData, {
+				metadata: { title: "Rechnung 471102" },
+			});
+
+			const result = await validatePdfA3b(verapdf!, pdfA);
+			expect(result.output).toContain("PASS");
+			expect(result.passed).toBe(true);
+		},
+		120_000,
+	);
+});

--- a/packages/pdf/src/plugin.ts
+++ b/packages/pdf/src/plugin.ts
@@ -1,0 +1,45 @@
+import type { ZugferdContext, ZugferdPlugin } from "node-zugferd/types";
+import { renderPdf } from "./renderer";
+import { createFormatters } from "./utils/format";
+import type { CreatePdfOptions, PdfPluginOptions } from "./types";
+
+/**
+ * Adds a `createPdf` handler to the zugferd instance that renders the
+ * invoice data with the configured template, generates the Factur-X XML
+ * and returns a finished PDF/A-3b document with the XML embedded.
+ *
+ * ```ts
+ * const invoicer = zugferd({
+ *   profile: EN16931,
+ *   plugins: [pdf({ template: defaultTemplate() })],
+ * });
+ *
+ * const pdfA = await invoicer.createPdf(data);
+ * ```
+ */
+export const pdf = (options: PdfPluginOptions) =>
+	((ctx: ZugferdContext) => {
+		const formatters = createFormatters(options.intlLocale);
+
+		return {
+			createPdf: async (data: any, opts?: CreatePdfOptions) => {
+				ctx.logger.debug("[pdf:createPdf] Rendering template");
+				const docDefinition = await options.template({
+					data,
+					logger: ctx.logger,
+					formatters,
+				});
+
+				ctx.logger.debug("[pdf:createPdf] Generating PDF");
+				const pdfBuffer = await renderPdf(docDefinition, {
+					fonts: options.fonts,
+				});
+				ctx.logger.debug(
+					`[pdf:createPdf] Generated PDF size: ${pdfBuffer.length}`,
+				);
+
+				const invoice = ctx.document.create(data);
+				return await invoice.embedInPdf(pdfBuffer, opts);
+			},
+		};
+	}) satisfies ZugferdPlugin;

--- a/packages/pdf/src/renderer.ts
+++ b/packages/pdf/src/renderer.ts
@@ -1,0 +1,40 @@
+import PdfPrinter from "pdfmake";
+import type { TDocumentDefinitions, TFontDictionary } from "pdfmake/interfaces";
+import { getDefaultFonts } from "./fonts";
+import type { PdfFont } from "./types";
+
+export type RenderPdfOptions = {
+	fonts?: Record<string, PdfFont>;
+};
+
+/**
+ * Renders a pdfmake document definition to a PDF buffer with all fonts
+ * embedded, ready to be passed to node-zugferd's `embedInPdf`.
+ */
+export const renderPdf = async (
+	docDefinition: TDocumentDefinitions,
+	options: RenderPdfOptions = {},
+): Promise<Buffer> => {
+	const fonts = options.fonts ?? (await getDefaultFonts());
+	const defaultFont = Object.keys(fonts)[0];
+	if (!defaultFont) {
+		throw new Error("[@node-zugferd/pdf] At least one font is required.");
+	}
+
+	const printer = new PdfPrinter(fonts as unknown as TFontDictionary);
+	const doc = printer.createPdfKitDocument({
+		...docDefinition,
+		defaultStyle: {
+			font: defaultFont,
+			...docDefinition.defaultStyle,
+		},
+	});
+
+	return await new Promise<Buffer>((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		doc.on("data", (chunk: Buffer) => chunks.push(chunk));
+		doc.on("end", () => resolve(Buffer.concat(chunks)));
+		doc.on("error", reject);
+		doc.end();
+	});
+};

--- a/packages/pdf/src/templates/default/index.test.ts
+++ b/packages/pdf/src/templates/default/index.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { zugferd } from "node-zugferd";
+import { BASIC } from "node-zugferd/profile/basic";
+import type { TDocumentDefinitions } from "pdfmake/interfaces";
+import { defaultTemplate, type DefaultTemplateOptions } from ".";
+import { createFormatters } from "../../utils/format";
+import data from "../../test-utils/data/basic";
+
+const { context } = zugferd({ profile: BASIC, logger: { disabled: true } });
+
+const render = async (
+	options?: DefaultTemplateOptions,
+	overrides?: Record<string, any>,
+): Promise<TDocumentDefinitions> =>
+	await defaultTemplate(options)({
+		data: { ...data, ...overrides },
+		logger: context.logger,
+		formatters: createFormatters(),
+	});
+
+// normalize the (narrow) no-break spaces emitted by Intl for readable assertions
+const asText = (value: unknown) =>
+	JSON.stringify(value).replace(/[\u00A0\u202F]/g, " ");
+
+describe("defaultTemplate", () => {
+	it("renders the content required by § 14 Abs. 4 UStG", async () => {
+		const text = asText((await render()).content);
+
+		// seller and buyer
+		expect(text).toContain("Lieferant GmbH");
+		expect(text).toContain("Kunden AG Mitte");
+		// seller VAT identifier
+		expect(text).toContain("DE123456789");
+		// invoice number and dates
+		expect(text).toContain("Rechnung Nr. 471102");
+		expect(text).toContain("15.11.2024");
+		expect(text).toContain("14.11.2024");
+		// quantity and description of the supplied goods
+		expect(text).toContain("Trennblätter A4");
+		expect(text).toContain("20 Stk");
+		// net amount, tax rate, tax amount and gross total
+		expect(text).toContain("198,00 €");
+		expect(text).toContain("zzgl. 19 % USt.");
+		expect(text).toContain("37,62 €");
+		expect(text).toContain("235,62 €");
+	});
+
+	it("renders notes and payment terms", async () => {
+		const text = asText((await render()).content);
+
+		expect(text).toContain("Rechnung gemäß Bestellung vom 01.11.2024.");
+		expect(text).toContain("Zahlbar innerhalb 30 Tagen");
+	});
+
+	it("derives the sender line from the seller by default", async () => {
+		const text = asText((await render()).content);
+
+		expect(text).toContain(
+			"Lieferant GmbH · Lieferantenstraße 20 · 80333 München",
+		);
+	});
+
+	it("prefers a custom sender line", async () => {
+		const text = asText(
+			(await render({ senderLine: "Custom Sender Line" })).content,
+		);
+
+		expect(text).toContain("Custom Sender Line");
+	});
+
+	it("falls back to the seller's tax number without a VAT identifier", async () => {
+		const text = asText(
+			(
+				await render(undefined, {
+					transaction: {
+						...data.transaction,
+						tradeAgreement: {
+							...data.transaction.tradeAgreement,
+							seller: {
+								...data.transaction.tradeAgreement.seller,
+								taxRegistration: { localIdentifier: "201/113/40209" },
+							},
+						},
+					},
+				})
+			).content,
+		);
+
+		expect(text).toContain("Steuernummer");
+		expect(text).toContain("201/113/40209");
+	});
+
+	it("renders the customer number when the buyer has an identifier", async () => {
+		const text = asText(
+			(
+				await render(undefined, {
+					transaction: {
+						...data.transaction,
+						tradeAgreement: {
+							...data.transaction.tradeAgreement,
+							buyer: {
+								...data.transaction.tradeAgreement.buyer,
+								identifier: "10053",
+							},
+						},
+					},
+				})
+			).content,
+		);
+
+		expect(text).toContain("Kunden-Nr.");
+		expect(text).toContain("10053");
+	});
+
+	it("renders the invoicing period", async () => {
+		const text = asText(
+			(
+				await render(undefined, {
+					transaction: {
+						...data.transaction,
+						tradeSettlement: {
+							...data.transaction.tradeSettlement,
+							invoicingPeriod: {
+								startDate: new Date("2026-06-01"),
+								endDate: new Date("2026-06-30"),
+							},
+						},
+					},
+				})
+			).content,
+		);
+
+		expect(text).toContain("Leistungszeitraum");
+		expect(text).toContain("01.06.2026 – 30.06.2026");
+	});
+
+	it("applies label overrides", async () => {
+		const text = asText(
+			(await render({ labels: { invoiceTitle: "Invoice No." } })).content,
+		);
+
+		expect(text).toContain("Invoice No. 471102");
+		expect(text).not.toContain("Rechnung Nr.");
+	});
+
+	it("adds a header image when a logo is provided", async () => {
+		const logo = `data:image/png;base64,${Buffer.from("fake").toString("base64")}`;
+
+		expect((await render()).header).toBeUndefined();
+		expect(asText((await render({ logo })).header)).toContain(logo);
+	});
+
+	it("repeats the provided footer columns", async () => {
+		const definition = await render({
+			footer: { columns: ["Column A", "Column B"] },
+		});
+		const footer = asText(
+			typeof definition.footer === "function"
+				? definition.footer(1, 3, {
+						width: 595.28,
+						height: 841.89,
+						orientation: "portrait",
+					})
+				: definition.footer,
+		);
+
+		expect(footer).toContain("Column A");
+		expect(footer).toContain("Column B");
+		expect(footer).toContain("Seite 1 von 3");
+	});
+
+	it("throws a descriptive error without invoice lines", async () => {
+		await expect(render(undefined, { transaction: undefined })).rejects.toThrow(
+			/requires at least one invoice line/,
+		);
+	});
+});

--- a/packages/pdf/src/templates/default/index.ts
+++ b/packages/pdf/src/templates/default/index.ts
@@ -1,0 +1,394 @@
+import type {
+	Content,
+	TableCell,
+	TDocumentDefinitions,
+} from "pdfmake/interfaces";
+import type { InvoiceTemplate, TemplateContext } from "../../types";
+
+export type DefaultTemplateOptions = {
+	/**
+	 * Logo (PNG or JPEG) rendered in the top right corner.
+	 */
+	logo?: Buffer | Uint8Array | string;
+	/**
+	 * Width of the logo in pt.
+	 *
+	 * @default 140
+	 */
+	logoWidth?: number;
+	/**
+	 * Color used for table rules and emphasis.
+	 *
+	 * @default "#333333"
+	 */
+	accentColor?: string;
+	/**
+	 * Single line with the sender's address above the recipient's address
+	 * field (DIN 5008 "Rücksendeangabe"), e.g.
+	 * `"Lieferant GmbH · Lieferantenstraße 20 · 80333 München"`.
+	 * Defaults to a line derived from the seller data.
+	 */
+	senderLine?: string;
+	/**
+	 * Footer columns repeated on every page. Use them for the mandatory
+	 * German business details: company, registration court and number,
+	 * managing directors, bank details, …
+	 */
+	footer?: {
+		columns: string[];
+	};
+	/**
+	 * Overrides for individual labels of the built-in German label set.
+	 */
+	labels?: Partial<Record<keyof typeof defaultLabels, string>>;
+};
+
+const defaultLabels = {
+	invoice: "Rechnung",
+	invoiceTitle: "Rechnung Nr.",
+	invoiceNumber: "Rechnungs-Nr.",
+	invoiceDate: "Rechnungsdatum",
+	customerNumber: "Kunden-Nr.",
+	deliveryDate: "Lieferdatum",
+	servicePeriod: "Leistungszeitraum",
+	sellerVatId: "USt-IdNr.",
+	sellerTaxNumber: "Steuernummer",
+	position: "Pos.",
+	description: "Bezeichnung",
+	quantity: "Menge",
+	unitPrice: "Einzelpreis",
+	lineTotal: "Gesamt",
+	netAmounts: "Beträge in EUR (netto)",
+	subtotal: "Zwischensumme (netto)",
+	allowances: "Nachlässe",
+	charges: "Zuschläge",
+	taxBasis: "Steuerbasis (netto)",
+	vat: "USt.",
+	grandTotal: "Gesamtbetrag",
+	prepaid: "Bereits gezahlt",
+	duePayable: "Zahlbetrag",
+	page: "Seite",
+	of: "von",
+} as const;
+
+const joinAddress = (party: any): string[] => {
+	const address = party?.postalAddress ?? {};
+	return [
+		party?.name,
+		address.line1,
+		address.line2,
+		address.line3,
+		[address.postCode, address.city].filter(Boolean).join(" "),
+	].filter((line) => !!line && String(line).trim().length > 0);
+};
+
+/**
+ * The built-in invoice template: a classic German business letter layout
+ * (DIN 5008 inspired) rendering all content required by § 14 Abs. 4 UStG
+ * from the invoice data. Requires the BASIC profile or higher, since
+ * MINIMUM and BASIC WL lack line items and are not valid invoices under
+ * German fiscal law.
+ */
+export const defaultTemplate = (
+	options: DefaultTemplateOptions = {},
+): InvoiceTemplate => {
+	const labels = { ...defaultLabels, ...options.labels };
+	const accent = options.accentColor ?? "#333333";
+
+	return (ctx: TemplateContext): TDocumentDefinitions => {
+		const { data, formatters } = ctx;
+
+		const lines: any[] = data.transaction?.line ?? [];
+		if (lines.length === 0) {
+			throw new Error(
+				"[@node-zugferd/pdf] The default template requires at least one invoice line (profile BASIC or higher). Provide a custom template for line-less profiles.",
+			);
+		}
+
+		const seller = data.transaction?.tradeAgreement?.seller ?? {};
+		const buyer = data.transaction?.tradeAgreement?.buyer ?? {};
+		const settlement = data.transaction?.tradeSettlement ?? {};
+		const summation = settlement.monetarySummation ?? {};
+		const currency = settlement.currencyCode;
+		const vatBreakdown: any[] = settlement.vatBreakdown ?? [];
+		const deliveryDate =
+			data.transaction?.tradeDelivery?.information?.deliveryDate;
+
+		const currencyFmt = (value: string | number | undefined) =>
+			value === undefined ? "" : formatters.currency(value, currency);
+
+		const senderLine =
+			options.senderLine ??
+			[seller.name, ...joinAddress(seller).slice(1)].join(" · ");
+
+		const metaRows: Array<[string, string]> = [
+			[labels.invoiceNumber, String(data.number ?? "")],
+			[
+				labels.invoiceDate,
+				data.issueDate ? formatters.date(data.issueDate) : "",
+			],
+		];
+		if (buyer.identifier) {
+			metaRows.push([labels.customerNumber, String(buyer.identifier)]);
+		}
+		if (deliveryDate) {
+			metaRows.push([labels.deliveryDate, formatters.date(deliveryDate)]);
+		}
+		const invoicingPeriod = settlement.invoicingPeriod;
+		if (invoicingPeriod?.startDate || invoicingPeriod?.endDate) {
+			metaRows.push([
+				labels.servicePeriod,
+				[
+					invoicingPeriod.startDate &&
+						formatters.date(invoicingPeriod.startDate),
+					invoicingPeriod.endDate && formatters.date(invoicingPeriod.endDate),
+				]
+					.filter(Boolean)
+					.join(" – "),
+			]);
+		}
+		if (seller.taxRegistration?.vatIdentifier) {
+			metaRows.push([labels.sellerVatId, seller.taxRegistration.vatIdentifier]);
+		} else if (seller.taxRegistration?.localIdentifier) {
+			metaRows.push([
+				labels.sellerTaxNumber,
+				seller.taxRegistration.localIdentifier,
+			]);
+		}
+
+		const percent = (rate: string | number | undefined) =>
+			rate === undefined ? "" : `${formatters.quantity(rate)} %`;
+
+		const lineRows: TableCell[][] = lines.map((line, index) => {
+			const quantity = line.tradeDelivery?.billedQuantity;
+			const unitPrice = line.tradeAgreement?.netTradePrice?.chargeAmount;
+			const lineTotal =
+				line.tradeSettlement?.monetarySummation?.lineTotalAmount ??
+				(unitPrice !== undefined && quantity?.amount !== undefined
+					? Number(unitPrice) * Number(quantity.amount)
+					: undefined);
+			const vatRate = line.tradeSettlement?.tradeTax?.rateApplicablePercent;
+
+			return [
+				{ text: line.identifier ?? String(index + 1), alignment: "right" },
+				{ text: line.tradeProduct?.name ?? "" },
+				{
+					text: quantity
+						? formatters.quantity(quantity.amount, quantity.unitMeasureCode)
+						: "",
+					alignment: "right",
+				},
+				{ text: currencyFmt(unitPrice), alignment: "right" },
+				{ text: percent(vatRate), alignment: "right" },
+				{ text: currencyFmt(lineTotal), alignment: "right" },
+			];
+		});
+
+		const totalRows: Array<[string, string, boolean?]> = [];
+		if (summation.lineTotalAmount !== undefined) {
+			totalRows.push([labels.subtotal, currencyFmt(summation.lineTotalAmount)]);
+		}
+		if (Number(summation.allowanceTotalAmount ?? 0) !== 0) {
+			totalRows.push([
+				labels.allowances,
+				`- ${currencyFmt(summation.allowanceTotalAmount)}`,
+			]);
+		}
+		if (Number(summation.chargeTotalAmount ?? 0) !== 0) {
+			totalRows.push([
+				labels.charges,
+				currencyFmt(summation.chargeTotalAmount),
+			]);
+		}
+		if (
+			summation.taxBasisTotalAmount !== undefined &&
+			summation.taxBasisTotalAmount !== summation.lineTotalAmount
+		) {
+			totalRows.push([
+				labels.taxBasis,
+				currencyFmt(summation.taxBasisTotalAmount),
+			]);
+		}
+		for (const vat of vatBreakdown) {
+			totalRows.push([
+				`zzgl. ${percent(vat.rateApplicablePercent ?? 0)} ${labels.vat}`,
+				currencyFmt(vat.calculatedAmount),
+			]);
+		}
+		if (summation.grandTotalAmount !== undefined) {
+			totalRows.push([
+				labels.grandTotal,
+				currencyFmt(summation.grandTotalAmount),
+				true,
+			]);
+		}
+		if (Number(summation.prepaidAmount ?? 0) !== 0) {
+			totalRows.push([
+				labels.prepaid,
+				`- ${currencyFmt(summation.prepaidAmount)}`,
+			]);
+			totalRows.push([
+				labels.duePayable,
+				currencyFmt(summation.duePayableAmount),
+				true,
+			]);
+		}
+
+		const exemptionNotes = vatBreakdown
+			.map((vat) => vat.exemptionReason)
+			.filter(Boolean);
+		const notes: string[] = [
+			...(data.includedNote ?? []).map((note: any) => note.content),
+			...(settlement.paymentTerms?.description
+				? [settlement.paymentTerms.description]
+				: []),
+			...exemptionNotes,
+		].filter(Boolean);
+
+		const content: Content[] = [
+			// address field + document meta
+			{
+				columns: [
+					{
+						width: "*",
+						stack: [
+							{
+								text: senderLine,
+								fontSize: 7,
+								color: "#666666",
+								margin: [0, 0, 0, 8],
+							},
+							{ text: joinAddress(buyer).join("\n"), lineHeight: 1.2 },
+						],
+					},
+					{
+						width: "auto",
+						table: {
+							body: metaRows.map(([label, value]) => [
+								{ text: label, color: "#666666" },
+								{ text: value, alignment: "right" },
+							]),
+						},
+						layout: "noBorders",
+						fontSize: 9,
+					},
+				],
+				columnGap: 24,
+				margin: [0, 60, 0, 32],
+			},
+			// title
+			{
+				text: `${labels.invoiceTitle} ${data.number ?? ""}`,
+				bold: true,
+				fontSize: 13,
+				color: accent,
+				margin: [0, 0, 0, 12],
+			},
+			// line items
+			{
+				table: {
+					headerRows: 1,
+					widths: [24, "*", 55, 65, 40, 70],
+					body: [
+						(
+							[
+								[labels.position, "right"],
+								[labels.description, "left"],
+								[labels.quantity, "right"],
+								[labels.unitPrice, "right"],
+								[labels.vat, "right"],
+								[labels.lineTotal, "right"],
+							] as const
+						).map(
+							([text, alignment]): TableCell => ({
+								text,
+								alignment,
+								bold: true,
+								color: accent,
+							}),
+						),
+						...lineRows,
+					],
+				},
+				layout: {
+					hLineWidth: (i: number, node: any) =>
+						i === 0 || i === 1 || i === node.table.body.length ? 0.75 : 0.25,
+					vLineWidth: () => 0,
+					hLineColor: () => accent,
+					paddingTop: () => 5,
+					paddingBottom: () => 5,
+				},
+				fontSize: 9,
+			},
+			// totals
+			{
+				columns: [
+					{ width: "*", text: "" },
+					{
+						width: "auto",
+						table: {
+							body: totalRows.map(([label, value, emphasized]) => [
+								{ text: label, bold: !!emphasized },
+								{ text: value, alignment: "right", bold: !!emphasized },
+							]),
+						},
+						layout: "noBorders",
+						fontSize: 9,
+					},
+				],
+				margin: [0, 12, 0, 24],
+			},
+			// notes, payment terms, tax exemption reasons
+			...notes.map(
+				(note): Content => ({
+					text: note,
+					fontSize: 9,
+					margin: [0, 0, 0, 8],
+				}),
+			),
+		];
+
+		return {
+			pageSize: "A4",
+			pageMargins: [57, 40, 42, options.footer ? 90 : 60],
+			...(options.logo
+				? {
+						header: {
+							image:
+								typeof options.logo === "string"
+									? options.logo
+									: `data:image/png;base64,${Buffer.from(options.logo).toString("base64")}`,
+							width: options.logoWidth ?? 140,
+							alignment: "right",
+							margin: [0, 24, 42, 0],
+						},
+					}
+				: {}),
+			footer: (currentPage, pageCount) => ({
+				stack: [
+					...(options.footer
+						? [
+								{
+									columns: options.footer.columns.map((column) => ({
+										text: column,
+										fontSize: 7,
+										color: "#666666",
+									})),
+									columnGap: 16,
+								},
+							]
+						: []),
+					{
+						text: `${labels.page} ${currentPage} ${labels.of} ${pageCount}`,
+						alignment: "right",
+						fontSize: 7,
+						color: "#666666",
+						margin: [0, 6, 0, 0],
+					},
+				],
+				margin: [57, 12, 42, 0],
+			}),
+			content,
+		};
+	};
+};

--- a/packages/pdf/src/templates/index.ts
+++ b/packages/pdf/src/templates/index.ts
@@ -1,0 +1,4 @@
+export {
+	defaultTemplate,
+	type DefaultTemplateOptions,
+} from "./default";

--- a/packages/pdf/src/test-utils/data/basic.ts
+++ b/packages/pdf/src/test-utils/data/basic.ts
@@ -1,0 +1,124 @@
+import type { ProfileBasic } from "node-zugferd/profile";
+
+const data: ProfileBasic = {
+	number: "471102",
+	typeCode: "380",
+	issueDate: new Date("2024-11-15"),
+	includedNote: [
+		{
+			content: "Rechnung gemäß Bestellung vom 01.11.2024.",
+		},
+		{
+			content: `Lieferant GmbH				
+Lieferantenstraße 20				
+80333 München				
+Deutschland				
+Geschäftsführer: Hans Muster
+Handelsregisternummer: H A 123`,
+		},
+		{
+			content: `Unsere GLN: 4000001123452
+Ihre GLN: 4000001987658
+Ihre Kundennummer: GE2020211
+
+
+Zahlbar innerhalb 30 Tagen netto bis 25.12.2024, 3% Skonto innerhalb 10 Tagen bis 25.11.2024.`,
+		},
+	],
+	transaction: {
+		line: [
+			{
+				identifier: "1",
+				tradeProduct: {
+					globalIdentifier: {
+						schemeIdentifier: "0160",
+						value: "4012345001235",
+					},
+					name: `GTIN: 4012345001235
+Unsere Art.-Nr.: TB100A4
+Trennblätter A4`,
+				},
+				tradeAgreement: {
+					netTradePrice: {
+						chargeAmount: "9.90",
+					},
+				},
+				tradeDelivery: {
+					billedQuantity: {
+						unitMeasureCode: "H87",
+						amount: "20.0000",
+					},
+				},
+				tradeSettlement: {
+					tradeTax: {
+						typeCode: "VAT",
+						categoryCode: "S",
+						rateApplicablePercent: "19",
+					},
+					monetarySummation: {
+						lineTotalAmount: "198.00",
+					},
+				},
+			},
+		],
+		tradeAgreement: {
+			seller: {
+				name: "Lieferant GmbH",
+				postalAddress: {
+					postCode: "80333",
+					line1: "Lieferantenstraße 20",
+					city: "München",
+					countryCode: "DE",
+				},
+				taxRegistration: {
+					localIdentifier: "201/113/40209",
+					vatIdentifier: "DE123456789",
+				},
+			},
+			buyer: {
+				name: "Kunden AG Mitte",
+				postalAddress: {
+					postCode: "69876",
+					line1: "Hans Muster",
+					line2: "Kundenstraße 15",
+					city: "Frankfurt",
+					countryCode: "DE",
+				},
+			},
+		},
+		tradeDelivery: {
+			information: {
+				deliveryDate: new Date("2024-11-14"),
+			},
+		},
+		tradeSettlement: {
+			currencyCode: "EUR",
+			vatBreakdown: [
+				{
+					calculatedAmount: "37.62",
+					typeCode: "VAT",
+					basisAmount: "198.00",
+					categoryCode: "S",
+					rateApplicablePercent: "19.00",
+				},
+			],
+			paymentTerms: {
+				dueDate: new Date("2024-12-15"),
+			},
+			monetarySummation: {
+				lineTotalAmount: "198.00",
+				chargeTotalAmount: "0.00",
+				allowanceTotalAmount: "0.00",
+				taxBasisTotalAmount: "198.00",
+				taxTotal: {
+					amount: "37.62",
+					currencyCode: "EUR",
+				},
+				grandTotalAmount: "235.62",
+				duePayableAmount: "235.62",
+			},
+		},
+	},
+};
+
+export default data;

--- a/packages/pdf/src/test-utils/data/en16931.ts
+++ b/packages/pdf/src/test-utils/data/en16931.ts
@@ -1,0 +1,134 @@
+import type { ProfileEN16931 } from "node-zugferd/profile";
+
+const data: ProfileEN16931 = {
+	number: "47110819",
+	typeCode: "380",
+	issueDate: new Date("2024-11-15"),
+	includedNote: [
+		{
+			content: `Mitglieder der Geschäftsleitung:
+Geschäftsführerin: Johanna Musterfrau
+Prokuristin: Isabell Herrlich
+HRB Berlin 13086`,
+		},
+	],
+	transaction: {
+		line: [
+			{
+				identifier: "1",
+				tradeProduct: {
+					name: "Lieferung und Montage Bauträger",
+				},
+				tradeAgreement: {
+					netTradePrice: {
+						chargeAmount: "20000.00",
+						basisQuantity: {
+							amount: 1,
+							unitMeasureCode: "H87",
+						},
+					},
+				},
+				tradeDelivery: {
+					billedQuantity: {
+						amount: 1,
+						unitMeasureCode: "H87",
+					},
+				},
+				tradeSettlement: {
+					tradeTax: {
+						typeCode: "VAT",
+						categoryCode: "S",
+						rateApplicablePercent: "19",
+					},
+					linePeriod: {
+						startDate: new Date("2024-06-01"),
+						endDate: new Date("2024-10-31"),
+					},
+					monetarySummation: {
+						lineTotalAmount: "20000",
+					},
+				},
+			},
+		],
+		tradeAgreement: {
+			seller: {
+				name: "Groß und Breit Bau AG",
+				postalAddress: {
+					postCode: "12345",
+					line1: "Erdkuhl 5",
+					city: "Berlin",
+					countryCode: "DE",
+				},
+				taxRegistration: {
+					vatIdentifier: "DE999999999",
+				},
+			},
+			buyer: {
+				identifier: "D75969813",
+				name: "Metallbau Leipzig GmbH &amp; Co. KG",
+				postalAddress: {
+					postCode: "12345",
+					line1: "Pappelallee 15",
+					line2: "Hof 3",
+					city: "Leipzig",
+					countryCode: "DE",
+				},
+				taxRegistration: {
+					vatIdentifier: "DE123456789",
+				},
+			},
+		},
+		tradeDelivery: {
+			shipTo: {
+				name: "Baustelle",
+				postalAddress: {
+					postCode: "98765",
+					line1: "Eichenpromenade 37",
+					line2: "Tor 1",
+					city: "Metallstadt",
+					countryCode: "DE",
+				},
+			},
+			information: {
+				deliveryDate: new Date("2024-10-31"),
+			},
+		},
+		tradeSettlement: {
+			currencyCode: "EUR",
+			paymentInstruction: {
+				typeCode: "58",
+				transfers: [
+					{
+						accountName: "Groß und Breit Bau AG",
+						paymentAccountIdentifier: "DE77 3707 0060 0321 9870 00",
+					},
+				],
+			},
+			vatBreakdown: [
+				{
+					calculatedAmount: "3800",
+					typeCode: "VAT",
+					basisAmount: "20000",
+					categoryCode: "S",
+					rateApplicablePercent: "19",
+				},
+			],
+			paymentTerms: {
+				dueDate: new Date("2024-11-29"),
+			},
+			monetarySummation: {
+				lineTotalAmount: "20000.00",
+				taxBasisTotalAmount: "20000.00",
+				taxTotal: {
+					currencyCode: "EUR",
+					amount: "3800.00",
+				},
+				grandTotalAmount: "23800.00",
+				paidAmount: "11900.00",
+				duePayableAmount: "11900.00",
+			},
+		},
+	},
+};
+
+export default data;

--- a/packages/pdf/src/test-utils/pdf.ts
+++ b/packages/pdf/src/test-utils/pdf.ts
@@ -1,0 +1,8 @@
+export const isPdfA3b = (input: Uint8Array<ArrayBufferLike>) => {
+	const text = new TextDecoder("utf-8").decode(input);
+
+	return (
+		text.includes("<pdfaid:part>3</pdfaid:part>") &&
+		text.includes("<pdfaid:conformance>B</pdfaid:conformance>")
+	);
+};

--- a/packages/pdf/src/test-utils/verapdf.ts
+++ b/packages/pdf/src/test-utils/verapdf.ts
@@ -1,0 +1,61 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Resolves a veraPDF CLI binary, either from the `VERAPDF` environment
+ * variable or from the PATH. Returns `undefined` when unavailable so
+ * conformance tests can be skipped instead of failing — mirroring how the
+ * core treats its optional XSD validator.
+ */
+export const findVeraPdf = async (): Promise<string | undefined> => {
+	const candidate = process.env.VERAPDF;
+	if (candidate) {
+		try {
+			await fs.access(candidate);
+			return candidate;
+		} catch {
+			return undefined;
+		}
+	}
+
+	return await new Promise((resolve) => {
+		execFile("which", ["verapdf"], (error, stdout) => {
+			resolve(error ? undefined : stdout.trim() || undefined);
+		});
+	});
+};
+
+export const validatePdfA3b = async (
+	verapdf: string,
+	pdf: Uint8Array,
+): Promise<{ passed: boolean; output: string }> => {
+	const file = path.join(
+		await fs.mkdtemp(path.join(os.tmpdir(), "node-zugferd-pdf-")),
+		"document.pdf",
+	);
+	await fs.writeFile(file, pdf);
+
+	try {
+		return await new Promise((resolve, reject) => {
+			execFile(
+				verapdf,
+				["-f", "3b", "--format", "text", file],
+				{ timeout: 120_000 },
+				(error, stdout, stderr) => {
+					const output = `${stdout}\n${stderr}`;
+					// veraPDF exits non-zero for failed validations, only treat
+					// missing PASS/FAIL output as an execution error
+					if (/^(PASS|FAIL)/m.test(stdout)) {
+						resolve({ passed: /^PASS/m.test(stdout), output });
+					} else {
+						reject(error ?? new Error(output));
+					}
+				},
+			);
+		});
+	} finally {
+		await fs.rm(path.dirname(file), { recursive: true, force: true });
+	}
+};

--- a/packages/pdf/src/types.ts
+++ b/packages/pdf/src/types.ts
@@ -1,0 +1,74 @@
+import type { ZugferdContext } from "node-zugferd/types";
+import type { TDocumentDefinitions } from "pdfmake/interfaces";
+
+export type Promisable<T> = T | Promise<T>;
+
+export type Formatters = {
+	/**
+	 * Formats a monetary amount including its currency symbol.
+	 *
+	 * @param currencyCode - ISO 4217 code
+	 * @default "EUR"
+	 */
+	currency: (value: string | number, currencyCode?: string) => string;
+	date: (value: Date) => string;
+	/**
+	 * Formats a quantity with a human readable unit derived from its
+	 * UN/ECE Recommendation 20 code (e.g. `H87` -> `Stk`). Unknown codes
+	 * fall back to the raw code.
+	 */
+	quantity: (value: string | number, unitCode?: string) => string;
+};
+
+export type TemplateContext<TData = any> = {
+	/**
+	 * The invoice data, exactly as passed to `createPdf`. This is the same
+	 * data the Factur-X XML is generated from, so a template rendering only
+	 * from it can never contradict the embedded XML.
+	 */
+	data: TData;
+	logger: ZugferdContext["logger"];
+	formatters: Formatters;
+};
+
+/**
+ * A template turns invoice data into a pdfmake document definition.
+ * Any function with this shape can be used, the built-in default template
+ * is just one implementation.
+ */
+export type InvoiceTemplate<TData = any> = (
+	ctx: TemplateContext<TData>,
+) => Promisable<TDocumentDefinitions>;
+
+/**
+ * A single embeddable font family. PDF/A-3 requires all fonts to be
+ * embedded, therefore only font buffers (TTF) are accepted, never names of
+ * PDF standard fonts.
+ */
+export type PdfFont = {
+	normal: Buffer;
+	bold: Buffer;
+	italics: Buffer;
+	bolditalics: Buffer;
+};
+
+export type PdfPluginOptions = {
+	template: InvoiceTemplate;
+	/**
+	 * BCP 47 locale used by the built-in number/date formatters.
+	 *
+	 * @default "de-DE"
+	 */
+	intlLocale?: string;
+	/**
+	 * Custom fonts available to templates, keyed by family name. The first
+	 * entry is used as the document's default font.
+	 *
+	 * @default The Roboto family shipped with pdfmake
+	 */
+	fonts?: Record<string, PdfFont>;
+};
+
+export type CreatePdfOptions = NonNullable<
+	Parameters<ReturnType<ZugferdContext["document"]["create"]>["embedInPdf"]>[1]
+>;

--- a/packages/pdf/src/utils/format.test.ts
+++ b/packages/pdf/src/utils/format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createFormatters } from "./format";
+
+// Intl emits non-breaking / narrow non-breaking spaces, normalize for
+// readable assertions
+const plain = (value: string) => value.replace(/[\u00A0\u202F]/g, " ");
+
+describe("createFormatters", () => {
+	const formatters = createFormatters();
+
+	it("formats currency amounts in German notation", () => {
+		expect(plain(formatters.currency("1234.56"))).toBe("1.234,56 €");
+		expect(plain(formatters.currency(0, "USD"))).toBe("0,00 $");
+	});
+
+	it("formats dates in German notation", () => {
+		expect(formatters.date(new Date("2024-11-15"))).toBe("15.11.2024");
+	});
+
+	it("formats quantities with human readable units", () => {
+		expect(plain(formatters.quantity("20.0000", "H87"))).toBe("20 Stk");
+		expect(plain(formatters.quantity(1.5, "HUR"))).toBe("1,5 Std.");
+	});
+
+	it("falls back to the raw unit code for unknown units", () => {
+		expect(plain(formatters.quantity(3, "XYZ"))).toBe("3 XYZ");
+	});
+
+	it("omits the unit when no code is given", () => {
+		expect(plain(formatters.quantity("2"))).toBe("2");
+	});
+
+	it("respects a custom locale", () => {
+		const en = createFormatters("en-US");
+		expect(plain(en.currency("1234.56"))).toBe("€1,234.56");
+	});
+});

--- a/packages/pdf/src/utils/format.ts
+++ b/packages/pdf/src/utils/format.ts
@@ -1,0 +1,46 @@
+import type { Formatters } from "../types";
+
+/**
+ * Human readable labels for the most common UN/ECE Recommendation 20 unit
+ * codes on invoices. Unknown codes fall back to the raw code.
+ */
+const UNIT_LABELS: Record<string, string> = {
+	C62: "Stk",
+	H87: "Stk",
+	HUR: "Std.",
+	DAY: "Tage",
+	MON: "Monate",
+	KGM: "kg",
+	GRM: "g",
+	TNE: "t",
+	MTR: "m",
+	MTK: "m²",
+	MTQ: "m³",
+	KMT: "km",
+	LTR: "l",
+	KWH: "kWh",
+	P1: "%",
+};
+
+export const createFormatters = (intlLocale = "de-DE"): Formatters => {
+	const number = new Intl.NumberFormat(intlLocale, {
+		maximumFractionDigits: 2,
+	});
+	const date = new Intl.DateTimeFormat(intlLocale, {
+		dateStyle: "medium",
+	});
+
+	return {
+		currency: (value, currencyCode = "EUR") =>
+			new Intl.NumberFormat(intlLocale, {
+				style: "currency",
+				currency: currencyCode,
+			}).format(Number(value)),
+		date: (value) => date.format(value),
+		quantity: (value, unitCode) => {
+			const formatted = number.format(Number(value));
+			if (!unitCode) return formatted;
+			return `${formatted} ${UNIT_LABELS[unitCode] ?? unitCode}`;
+		},
+	};
+};

--- a/packages/pdf/tsconfig.json
+++ b/packages/pdf/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"target": "es2022",
+		"allowJs": true,
+		"resolveJsonModule": true,
+		"module": "Preserve",
+		"noEmit": true,
+		"types": ["node"],
+		"moduleResolution": "Bundler",
+		"moduleDetection": "force",
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"composite": false,
+		"incremental": true,
+		"tsBuildInfoFile": ".tsbuildinfo",
+		"strict": true,
+		"noImplicitOverride": true,
+		"noFallthroughCasesInSwitch": true,
+		"downlevelIteration": true
+	},
+	"exclude": ["**/dist", "node_modules"],
+	"references": [],
+	"include": ["src/**/*"]
+}

--- a/packages/pdf/tsup.config.ts
+++ b/packages/pdf/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig(() => {
+	return {
+		entry: {
+			index: "./src/index.ts",
+			templates: "./src/templates/index.ts",
+		},
+		format: ["cjs", "esm"],
+		bundle: true,
+		splitting: false,
+		cjsInterop: true,
+		skipNodeModulesBundle: true,
+	};
+});

--- a/packages/pdf/vitest.config.ts
+++ b/packages/pdf/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,37 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0(typescript@5.8.3)(zod@3.25.76)
 
+  packages/pdf:
+    dependencies:
+      node-zugferd:
+        specifier: workspace:*
+        version: link:../node-zugferd
+      pdfmake:
+        specifier: ^0.2.20
+        version: 0.2.23
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 1.9.4
+        version: 1.9.4
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.13.4
+      '@types/pdfmake':
+        specifier: ^0.2.11
+        version: 0.2.13
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      vitest:
+        specifier: ^3.0.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.13.4)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.0)
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -831,6 +862,18 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@foliojs-fork/fontkit@1.9.2':
+    resolution: {integrity: sha512-IfB5EiIb+GZk+77TRB86AHroVaqfq8JRFlUbz0WEwsInyCG0epX2tCPOy+UfaWPju30DeVoUAXfzWXmhn753KA==}
+
+  '@foliojs-fork/linebreak@1.1.2':
+    resolution: {integrity: sha512-ZPohpxxbuKNE0l/5iBJnOAfUaMACwvUIKCvqtWGKIMv1lPYoNjYXRfhi9FeeV9McBkBLxsMFWTVVhHJA8cyzvg==}
+
+  '@foliojs-fork/pdfkit@0.15.3':
+    resolution: {integrity: sha512-Obc0Wmy3bm7BINFVvPhcl2rnSSK61DQrlHU8aXnAqDk9LCjWdUOPwhgD8Ywz5VtuFjRxmVOM/kQ/XLIBjDvltw==}
+
+  '@foliojs-fork/restructure@2.0.2':
+    resolution: {integrity: sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==}
 
   '@formatjs/intl-localematcher@0.6.1':
     resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
@@ -1924,6 +1967,12 @@ packages:
   '@types/node@22.13.4':
     resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
 
+  '@types/pdfkit@0.17.6':
+    resolution: {integrity: sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==}
+
+  '@types/pdfmake@0.2.13':
+    resolution: {integrity: sha512-QzOwk3dMTZOwVbDZNHGIQcpwBgprp1y1vzRBmR+p+vMtCZo00G1CN+YhNebkygtmaGjdzvyXJVOHMEuTbvhJ8A==}
+
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
 
@@ -2143,6 +2192,12 @@ packages:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
     engines: {node: '>= 0.4'}
 
+  base64-js@1.3.1:
+    resolution: {integrity: sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
@@ -2159,6 +2214,12 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.25.1:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
@@ -2181,7 +2242,6 @@ packages:
 
   bun@1.3.5:
     resolution: {integrity: sha512-c1YHIGUfgvYPJmLug5QiLzNWlX2Dg7X/67JWu1Va+AmMXNXzC/KQn2lgQ7rD+n1u1UqDpJMowVGGxTNpbPydNw==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2202,6 +2262,18 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -2269,6 +2341,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -2334,6 +2410,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
   css-background-parser@0.1.0:
     resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
 
@@ -2386,6 +2465,18 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-equal@1.1.2:
+    resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
+    engines: {node: '>= 0.4'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
@@ -2413,6 +2504,9 @@ packages:
   devtools-protocol@0.0.1464554:
     resolution: {integrity: sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==}
 
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -2429,6 +2523,10 @@ packages:
   dotenv@17.2.1:
     resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
     engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2470,8 +2568,20 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -2701,6 +2811,12 @@ packages:
       tailwindcss:
         optional: true
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
   geist@1.4.2:
     resolution: {integrity: sha512-OQUga/KUc8ueijck6EbtT07L4tZ5+TZgjw8PyWfxo16sL5FWk7gNViPNU8hgCFjy6bJi9yuTP+CRpywzaGN8zw==}
     peerDependencies:
@@ -2714,9 +2830,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
@@ -2742,7 +2866,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2750,6 +2879,21 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
@@ -2791,6 +2935,10 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   image-size@2.0.2:
     resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
@@ -2813,11 +2961,19 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -2852,6 +3008,10 @@ packages:
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2869,6 +3029,10 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  jpeg-exif@1.1.4:
+    resolution: {integrity: sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3042,6 +3206,10 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -3326,6 +3494,14 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -3406,6 +3582,10 @@ packages:
   pdf-lib@1.17.1:
     resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
+  pdfmake@0.2.23:
+    resolution: {integrity: sha512-A/IksoKb/ikOZH1edSDJ/2zBbqJKDghD4+fXn3rT7quvCJDlsZMs3NmIB3eajLMMFU9Bd3bZPVvlUMXhvFI+bQ==}
+    engines: {node: '>=18'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -3432,6 +3612,9 @@ packages:
 
   pkg-types@2.2.0:
     resolution: {integrity: sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==}
+
+  png-js@1.1.0:
+    resolution: {integrity: sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==}
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -3607,6 +3790,10 @@ packages:
   regex@6.0.1:
     resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
 
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
 
@@ -3668,6 +3855,10 @@ packages:
     resolution: {integrity: sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==}
     engines: {node: '>=16'}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -3702,6 +3893,14 @@ packages:
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
 
   sharp@0.34.3:
     resolution: {integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==}
@@ -4016,6 +4215,9 @@ packages:
     resolution: {integrity: sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==}
     engines: {node: '>=20.18.1'}
 
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
@@ -4207,6 +4409,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xmldoc@2.0.3:
+    resolution: {integrity: sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==}
+    engines: {node: '>=12.0.0'}
 
   xsd-schema-validator@0.10.0:
     resolution: {integrity: sha512-G1GtYp9Smww5D9U3QJy/uMeoaDlEYg5BR4qZYSBZWa/5TG5az2j3Np27uLKaRcg6ajwe3Ew6SJrAo3B/QFrgdg==}
@@ -4609,6 +4815,32 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@foliojs-fork/fontkit@1.9.2':
+    dependencies:
+      '@foliojs-fork/restructure': 2.0.2
+      brotli: 1.3.3
+      clone: 1.0.4
+      deep-equal: 1.1.2
+      dfa: 1.2.0
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
+
+  '@foliojs-fork/linebreak@1.1.2':
+    dependencies:
+      base64-js: 1.3.1
+      unicode-trie: 2.0.0
+
+  '@foliojs-fork/pdfkit@0.15.3':
+    dependencies:
+      '@foliojs-fork/fontkit': 1.9.2
+      '@foliojs-fork/linebreak': 1.1.2
+      crypto-js: 4.2.0
+      jpeg-exif: 1.1.4
+      png-js: 1.1.0
+
+  '@foliojs-fork/restructure@2.0.2': {}
 
   '@formatjs/intl-localematcher@0.6.1':
     dependencies:
@@ -5618,6 +5850,15 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
+  '@types/pdfkit@0.17.6':
+    dependencies:
+      '@types/node': 22.13.4
+
+  '@types/pdfmake@0.2.13':
+    dependencies:
+      '@types/node': 22.13.4
+      '@types/pdfkit': 0.17.6
+
   '@types/prismjs@1.26.5': {}
 
   '@types/qs@6.9.18': {}
@@ -5849,6 +6090,10 @@ snapshots:
 
   base64-js@0.0.8: {}
 
+  base64-js@1.3.1: {}
+
+  base64-js@1.5.1: {}
+
   basic-ftp@5.0.5: {}
 
   better-call@1.0.12:
@@ -5867,6 +6112,14 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.25.1:
     dependencies:
@@ -5934,6 +6187,23 @@ snapshots:
       rc9: 2.1.2
 
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -6012,6 +6282,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone@1.0.4: {}
+
   clsx@2.1.1: {}
 
   code-block-writer@13.0.3: {}
@@ -6069,6 +6341,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  crypto-js@4.2.0: {}
+
   css-background-parser@0.1.0: {}
 
   css-box-shadow@1.0.0-3: {}
@@ -6109,6 +6383,27 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deep-equal@1.1.2:
+    dependencies:
+      is-arguments: 1.2.0
+      is-date-object: 1.1.0
+      is-regex: 1.2.1
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      regexp.prototype.flags: 1.5.4
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
   defu@6.1.4: {}
 
   degenerator@5.0.1:
@@ -6131,6 +6426,8 @@ snapshots:
 
   devtools-protocol@0.0.1464554: {}
 
+  dfa@1.2.0: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -6150,6 +6447,12 @@ snapshots:
       domhandler: 5.0.3
 
   dotenv@17.2.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
 
@@ -6185,7 +6488,15 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -6507,6 +6818,10 @@ snapshots:
       - algoliasearch
       - supports-color
 
+  function-bind@1.1.2: {}
+
+  functions-have-names@1.2.3: {}
+
   geist@1.4.2(next@15.4.10(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
     dependencies:
       next: 15.4.10(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -6515,7 +6830,25 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-stream@5.2.0:
     dependencies:
@@ -6557,6 +6890,8 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   gray-matter@4.0.3:
@@ -6565,6 +6900,20 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-to-estree@3.1.3:
     dependencies:
@@ -6660,6 +7009,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   image-size@2.0.2: {}
 
   import-fresh@3.3.1:
@@ -6681,10 +7034,20 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-arrayish@0.2.1: {}
 
   is-arrayish@0.3.2:
     optional: true
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
 
@@ -6708,6 +7071,13 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
   isexe@2.0.0: {}
 
   isexe@3.1.1:
@@ -6722,6 +7092,8 @@ snapshots:
   jiti@2.5.1: {}
 
   joycon@3.1.1: {}
+
+  jpeg-exif@1.1.4: {}
 
   js-tokens@4.0.0: {}
 
@@ -6840,6 +7212,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -7389,6 +7763,13 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
   ohash@2.0.11: {}
 
   once@1.4.0:
@@ -7506,6 +7887,13 @@ snapshots:
       pako: 1.0.11
       tslib: 1.14.1
 
+  pdfmake@0.2.23:
+    dependencies:
+      '@foliojs-fork/linebreak': 1.1.2
+      '@foliojs-fork/pdfkit': 0.15.3
+      iconv-lite: 0.7.2
+      xmldoc: 2.0.3
+
   pend@1.2.0: {}
 
   perfect-debounce@1.0.0: {}
@@ -7529,6 +7917,10 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  png-js@1.1.0:
+    dependencies:
+      browserify-zlib: 0.2.0
 
   postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
@@ -7742,6 +8134,15 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
   rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -7859,6 +8260,8 @@ snapshots:
       postcss-value-parser: 4.2.0
       yoga-wasm-web: 0.3.3
 
+  sax@1.6.0: {}
+
   scheduler@0.26.0: {}
 
   scroll-into-view-if-needed@3.1.0:
@@ -7885,6 +8288,22 @@ snapshots:
   seroval@1.3.2: {}
 
   set-cookie-parser@2.7.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
 
   sharp@0.34.3:
     dependencies:
@@ -8237,6 +8656,11 @@ snapshots:
 
   undici@7.13.0: {}
 
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
   unicode-trie@2.0.0:
     dependencies:
       pako: 0.2.9
@@ -8441,6 +8865,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.3: {}
+
+  xmldoc@2.0.3:
+    dependencies:
+      sax: 1.6.0
 
   xsd-schema-validator@0.10.0:
     dependencies:


### PR DESCRIPTION
Closes #119

## What this PR does

Adds `@node-zugferd/pdf` — a new plugin package that turns invoice data into a finished e-invoice in a single call, with no server and no headless browser:

```ts
const invoicer = zugferd({
  profile: EN16931,
  plugins: [pdf({ template: defaultTemplate() })],
});

// renders the PDF, generates the XML, embeds it → PDF/A-3b Uint8Array
const pdfA = await invoicer.createPdf(data, { metadata: { title: "Rechnung 471102" } });
```

### Pipeline

```
data → template (pdfmake docDefinition) → pdfmake printer (fonts embedded)
     → document.create(data).embedInPdf(buffer) → PDF/A-3b with Factur-X XML
```

Only public core APIs are used (`ZugferdPlugin`, `document.create`, `embedInPdf`) — no core changes.

### Built-in German template

`defaultTemplate()` renders a classic German business invoice (DIN 5008 inspired) with all content required by § 14 Abs. 4 UStG: sender line, address field, document meta block (invoice number, dates, customer number, invoicing period, VAT ID / tax number), line item table with automatic page breaks, totals with per-rate VAT breakdown (incl. exemption reasons), notes / payment terms, and per-page footer columns.

It renders **exclusively from the same data the XML is generated from**, so the visible PDF cannot contradict the embedded XML. Customization tiers: options (logo, accent color, sender line, footer columns, label overrides — e.g. for English invoices) → fully custom template (any function returning a pdfmake document definition, with locale-aware formatters provided).

Since PDF/A forbids non-embedded fonts, the standard-14-fonts path is never used; the Roboto family shipped inside pdfmake is embedded by default, custom TTFs are supported via the `fonts` option.

## Testing

- 24 Vitest tests (files next to sources): formatter units, default-template content assertions against the shared profile fixtures, and full-pipeline integration tests (embedded `factur-x.xml` byte-equal to `toXML()`, EN 16931 profile, multi-page tables, custom templates).
- **veraPDF conformance**: output passes official PDF/A-3b validation (veraPDF 1.30.2). The conformance test auto-skips when no veraPDF binary is found (`VERAPDF` env or PATH), mirroring how the core treats its optional XSD validator — CI without veraPDF is unaffected.
- XSD validation was active (strict mode) in manual end-to-end runs with real invoice data.
- `typecheck`, `biome check` and `build` (incl. DTS) are clean; the docs site builds successfully.

## Docs

- New page `docs/content/docs/plugins/pdf.mdx` (installation, default template, custom fonts, custom templates, options reference), registered in the plugins sidebar.
- Package README.

## Open points

Happy to adjust naming (package name, `createPdf` handler), the bundled font, or anything else — see the open questions in #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jslno/node-zugferd/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

